### PR TITLE
Update two apis to use request param instead of path variable

### DIFF
--- a/src/main/java/org/mskcc/oncokb/transcript/web/rest/DrugResource.java
+++ b/src/main/java/org/mskcc/oncokb/transcript/web/rest/DrugResource.java
@@ -137,8 +137,8 @@ public class DrugResource {
         return drugService.findAll();
     }
 
-    @GetMapping("/drugs/search/{query}")
-    public List<Drug> findDrugs(@PathVariable(value = "query") String query) {
+    @GetMapping("/drugs/search")
+    public List<Drug> findDrugs(@RequestParam(value = "query") String query) {
         log.debug("REST request to search Drugs");
         return drugService.searchDrug(query);
     }

--- a/src/main/java/org/mskcc/oncokb/transcript/web/rest/GeneController.java
+++ b/src/main/java/org/mskcc/oncokb/transcript/web/rest/GeneController.java
@@ -32,8 +32,8 @@ public class GeneController {
      * @param symbol the id of the gene to retrieve.
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the gene, or with status {@code 404 (Not Found)}.
      */
-    @GetMapping("/find-gene/{symbol}")
-    public ResponseEntity<Gene> findGeneBySymbol(@PathVariable String symbol) {
+    @GetMapping("/find-gene")
+    public ResponseEntity<Gene> findGeneBySymbol(@RequestParam String symbol) {
         log.debug("REST request to find Gene : {}", symbol);
         return new ResponseEntity<>(getGeneBySymbol(symbol).orElse(null), HttpStatus.OK);
     }
@@ -44,14 +44,12 @@ public class GeneController {
         if (body != null) {
             body
                 .stream()
-                .forEach(
-                    symbol -> {
-                        Optional<Gene> geneOptional = getGeneBySymbol(symbol);
-                        if (geneOptional.isPresent()) {
-                            genes.add(geneOptional.get());
-                        }
+                .forEach(symbol -> {
+                    Optional<Gene> geneOptional = getGeneBySymbol(symbol);
+                    if (geneOptional.isPresent()) {
+                        genes.add(geneOptional.get());
                     }
-                );
+                });
         }
         return new ResponseEntity<>(genes, HttpStatus.OK);
     }


### PR DESCRIPTION
The path variable prohibits encoded html to be used.  https://www.baeldung.com/spring-slash-character-in-url
This fixes https://github.com/oncokb/oncokb-transcript/issues/25