### PR TITLE
Add cache resolver for transcript entity

### DIFF
--- a/src/main/java/org/mskcc/oncokb/transcript/config/cache/CacheCategory.java
+++ b/src/main/java/org/mskcc/oncokb/transcript/config/cache/CacheCategory.java
@@ -1,0 +1,6 @@
+package org.mskcc.oncokb.transcript.config.cache;
+
+public enum CacheCategory {
+    GENE,
+    TRANSCRIPT,
+}

--- a/src/main/java/org/mskcc/oncokb/transcript/config/cache/CacheKeys.java
+++ b/src/main/java/org/mskcc/oncokb/transcript/config/cache/CacheKeys.java
@@ -1,8 +1,10 @@
-package org.mskcc.oncokb.transcript.config;
+package org.mskcc.oncokb.transcript.config.cache;
 
 public final class CacheKeys {
 
     public static final String GENES_BY_ENTREZ_GENE_ID = "genesByEntrezGeneId";
     public static final String GENES_BY_HUGO_SYMBOL = "genesByHugoSymbol";
     public static final String GENE_ALIASES_BY_NAME = "geneAliasesByName";
+
+    public static final String TRANSCRIPTS_BY_ENSEMBL_TRANSCRIPT_IDS = "findByReferenceGenomeAndEnsemblTranscriptIdIsIn";
 }

--- a/src/main/java/org/mskcc/oncokb/transcript/config/cache/CacheNameResolver.java
+++ b/src/main/java/org/mskcc/oncokb/transcript/config/cache/CacheNameResolver.java
@@ -12,7 +12,7 @@ public class CacheNameResolver {
         this.applicationProperties = applicationProperties;
     }
 
-    public String getCacheName(String cacheKey) {
-        return applicationProperties.getName() + "-" + cacheKey;
+    public String getCacheName(CacheCategory cacheCategory, String cacheKey) {
+        return applicationProperties.getName() + "-" + cacheCategory + "-" + cacheKey;
     }
 }

--- a/src/main/java/org/mskcc/oncokb/transcript/config/cache/TranscriptCacheResolver.java
+++ b/src/main/java/org/mskcc/oncokb/transcript/config/cache/TranscriptCacheResolver.java
@@ -8,13 +8,17 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.interceptor.CacheOperationInvocationContext;
 import org.springframework.cache.interceptor.CacheResolver;
 
-public class GeneCacheResolver implements CacheResolver {
+public class TranscriptCacheResolver implements CacheResolver {
 
     private final ApplicationProperties applicationProperties;
     private final CacheManager cacheManager;
     private final CacheNameResolver cacheNameResolver;
 
-    public GeneCacheResolver(CacheManager cacheManager, ApplicationProperties applicationProperties, CacheNameResolver cacheNameResolver) {
+    public TranscriptCacheResolver(
+        CacheManager cacheManager,
+        ApplicationProperties applicationProperties,
+        CacheNameResolver cacheNameResolver
+    ) {
         this.cacheManager = cacheManager;
         this.applicationProperties = applicationProperties;
         this.cacheNameResolver = cacheNameResolver;
@@ -24,12 +28,12 @@ public class GeneCacheResolver implements CacheResolver {
     public Collection<? extends Cache> resolveCaches(CacheOperationInvocationContext<?> context) {
         Collection<Cache> caches = new ArrayList<>();
 
-        if (context.getMethod().getName() == "findByEntrezGeneId") {
-            caches.add(cacheManager.getCache(this.cacheNameResolver.getCacheName(CacheCategory.GENE, CacheKeys.GENES_BY_ENTREZ_GENE_ID)));
-        } else if (context.getMethod().getName() == "findByHugoSymbol") {
-            caches.add(cacheManager.getCache(this.cacheNameResolver.getCacheName(CacheCategory.GENE, CacheKeys.GENES_BY_HUGO_SYMBOL)));
-        } else if (context.getMethod().getName() == "findByName") {
-            caches.add(cacheManager.getCache(this.cacheNameResolver.getCacheName(CacheCategory.GENE, CacheKeys.GENE_ALIASES_BY_NAME)));
+        if (context.getMethod().getName() == "findByReferenceGenomeAndEnsemblTranscriptIdIsIn") {
+            caches.add(
+                cacheManager.getCache(
+                    this.cacheNameResolver.getCacheName(CacheCategory.TRANSCRIPT, CacheKeys.TRANSCRIPTS_BY_ENSEMBL_TRANSCRIPT_IDS)
+                )
+            );
         }
 
         return caches;

--- a/src/main/java/org/mskcc/oncokb/transcript/repository/TranscriptRepository.java
+++ b/src/main/java/org/mskcc/oncokb/transcript/repository/TranscriptRepository.java
@@ -6,6 +6,7 @@ import liquibase.pro.packaged.T;
 import org.mskcc.oncokb.transcript.domain.Transcript;
 import org.mskcc.oncokb.transcript.domain.enumeration.ReferenceGenome;
 import org.mskcc.oncokb.transcript.domain.enumeration.UsageSource;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.Repository;
 
@@ -32,6 +33,7 @@ public interface TranscriptRepository extends JpaRepository<Transcript, Long> {
 
     Optional<Transcript> findByReferenceGenomeAndEnsemblTranscriptId(ReferenceGenome referenceGenome, String ensemblTranscriptId);
 
+    @Cacheable(cacheResolver = "transcriptCacheResolver")
     List<Transcript> findByReferenceGenomeAndEnsemblTranscriptIdIsIn(ReferenceGenome referenceGenome, List<String> ensemblTranscriptIds);
 
     List<Transcript> findByReferenceGenome(ReferenceGenome referenceGenome);


### PR DESCRIPTION
Two main items added here
- Added a transcript cache resolver
- Remove all caches by category

We still need a general cache resolver. Was able to get/delete caches dynamically, but cannot dynamically add caches. The cache customizer is from JCache, but wasn't able to inject the JCache manager and config in the resolver which is needed when the cache is not available so we can create a new one. Still need to dive into more details.
Another option is to use the Redisson cache manager, the same implementation we did for the core service.