### PR TITLE
Fix ElasticSearch Sorting

### DIFF
--- a/src/main/java/org/mskcc/oncokb/curation/repository/search/ArticleSearchRepository.java
+++ b/src/main/java/org/mskcc/oncokb/curation/repository/search/ArticleSearchRepository.java
@@ -4,7 +4,6 @@ import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.mskcc.oncokb.curation.domain.Article;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;

--- a/src/main/java/org/mskcc/oncokb/curation/repository/search/CancerTypeSearchRepository.java
+++ b/src/main/java/org/mskcc/oncokb/curation/repository/search/CancerTypeSearchRepository.java
@@ -5,9 +5,11 @@ import java.util.stream.Collectors;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.WildcardQueryBuilder;
+import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.mskcc.oncokb.curation.domain.CancerType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -36,8 +38,19 @@ class CancerTypeSearchRepositoryInternalImpl implements CancerTypeSearchReposito
     @Override
     public Page<CancerType> search(String query, Pageable pageable) {
         QueryBuilder queryBuilder = QueryBuilders.boolQuery().should(new WildcardQueryBuilder("mainType", query + "*"));
-        NativeSearchQuery nativeSearchQuery = new NativeSearchQueryBuilder().withQuery(queryBuilder).withPageable(pageable).build();
-        SearchHits<CancerType> searchHits = elasticsearchTemplate.search(nativeSearchQuery, CancerType.class);
+
+        NativeSearchQueryBuilder nativeSearchQueryBuilder = new NativeSearchQueryBuilder()
+            .withQuery(queryBuilder)
+            .withPageable(PageRequest.of(pageable.getPageNumber(), pageable.getPageSize()));
+
+        List<FieldSortBuilder> sortBuilders = new SortToFieldSortBuilderConverter<>(CancerType.class).convert(pageable.getSort());
+        sortBuilders
+            .stream()
+            .forEach(sortBuilder -> {
+                nativeSearchQueryBuilder.withSort(sortBuilder);
+            });
+
+        SearchHits<CancerType> searchHits = elasticsearchTemplate.search(nativeSearchQueryBuilder.build(), CancerType.class);
         List<CancerType> hits = searchHits.map(SearchHit::getContent).stream().collect(Collectors.toList());
 
         return new PageImpl<>(hits, pageable, searchHits.getTotalHits());

--- a/src/main/java/org/mskcc/oncokb/curation/repository/search/CompanionDiagnosticDeviceSearchRepository.java
+++ b/src/main/java/org/mskcc/oncokb/curation/repository/search/CompanionDiagnosticDeviceSearchRepository.java
@@ -1,7 +1,5 @@
 package org.mskcc.oncokb.curation.repository.search;
 
-import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
-
 import java.util.stream.Stream;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;

--- a/src/main/java/org/mskcc/oncokb/curation/repository/search/SortToFieldSortBuilderConverter.java
+++ b/src/main/java/org/mskcc/oncokb/curation/repository/search/SortToFieldSortBuilderConverter.java
@@ -1,0 +1,39 @@
+package org.mskcc.oncokb.curation.repository.search;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortOrder;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.domain.Sort;
+
+/**
+ * Text fields are not available for sorting by default. The recommended way is to use multi-field mapping and a have the keyword field for sorting.
+ * The converter will attached the ".keyword" field to the property if it is of type String.
+ */
+
+public class SortToFieldSortBuilderConverter<T> implements Converter<Sort, List<FieldSortBuilder>> {
+
+    private Class<T> entityClass;
+
+    public SortToFieldSortBuilderConverter(Class<T> entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    @Override
+    public List<FieldSortBuilder> convert(Sort sort) {
+        List<FieldSortBuilder> builders = new ArrayList<>();
+        sort
+            .stream()
+            .forEach(order -> {
+                try {
+                    SortOrder sortOrder = SortOrder.fromString(order.getDirection().name());
+                    Boolean isStringField = entityClass.getDeclaredField(order.getProperty()).getType().equals(String.class);
+                    String property = isStringField ? order.getProperty() + ".keyword" : order.getProperty();
+                    builders.add(new FieldSortBuilder(property).order(sortOrder));
+                } catch (NoSuchFieldException e) {}
+            });
+        return builders;
+    }
+}

--- a/src/main/webapp/app/config/constants.ts
+++ b/src/main/webapp/app/config/constants.ts
@@ -95,6 +95,16 @@ export enum USER_AUTHORITY {
   ROLE_USER = 'ROLE_USER',
   ROLE_ADMIN = 'ROLE_ADMIN',
 }
+
 export const DEFAULT_SORT_PARAMETER = 'id,ASC';
+
+export const DEFAULT_SORT_DIRECTION = 'ASC';
+
+export const DEFAULT_ENTITY_SORT_FIELD: { [key in ENTITY_TYPE]?: string } = {
+  [ENTITY_TYPE.GENE]: 'hugoSymbol',
+  [ENTITY_TYPE.ALTERATION]: 'name',
+  [ENTITY_TYPE.DRUG]: 'name',
+  [ENTITY_TYPE.FDA_SUBMISSION]: 'deviceName',
+};
 
 export const FDA_SUBMISSION_REGEX = new RegExp('^([A-Z]+[0-9]+)(\\/((S[0-9]+)(-(S[0-9]+))?))?');

--- a/src/main/webapp/app/entities/alteration/alteration.tsx
+++ b/src/main/webapp/app/entities/alteration/alteration.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'app/shared/util/typed-inject';
-import { Link, RouteComponentProps } from 'react-router-dom';
-import { Button, Input, Col, Row } from 'reactstrap';
+import { RouteComponentProps } from 'react-router-dom';
+import { Input, Col, Row } from 'reactstrap';
 import { getSortState, JhiPagination, JhiItemCount } from 'react-jhipster';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IAlteration } from 'app/shared/model/alteration.model';
 import { ASC, DESC, ITEMS_PER_PAGE, SORT } from 'app/shared/util/pagination.constants';
 import { overridePaginationStateWithQueryParams } from 'app/shared/util/entity-utils';
@@ -12,14 +11,17 @@ import { Column } from 'react-table';
 import { TableHeader } from 'app/shared/table/TableHeader';
 import { debouncedSearchWithPagination } from 'app/shared/util/pagination-crud-store';
 import EntityTable from 'app/shared/table/EntityTable';
-import { ENTITY_ACTION, ENTITY_TYPE } from 'app/config/constants';
+import { DEFAULT_ENTITY_SORT_FIELD, ENTITY_ACTION, ENTITY_TYPE } from 'app/config/constants';
 import EntityActionButton from 'app/shared/button/EntityActionButton';
 export interface IAlterationProps extends StoreProps, RouteComponentProps<{ url: string }> {}
 
 export const Alteration = (props: IAlterationProps) => {
   const [search, setSearch] = useState('');
   const [paginationState, setPaginationState] = useState(
-    overridePaginationStateWithQueryParams(getSortState(props.location, ITEMS_PER_PAGE, 'id'), props.location.search)
+    overridePaginationStateWithQueryParams(
+      getSortState(props.location, ITEMS_PER_PAGE, DEFAULT_ENTITY_SORT_FIELD[ENTITY_TYPE.ALTERATION]),
+      props.location.search
+    )
   );
 
   const alterationList = props.alterationList;

--- a/src/main/webapp/app/entities/drug/drug.tsx
+++ b/src/main/webapp/app/entities/drug/drug.tsx
@@ -12,14 +12,17 @@ import { Column } from 'react-table';
 import { TableHeader } from 'app/shared/table/TableHeader';
 import { debouncedSearchWithPagination } from 'app/shared/util/pagination-crud-store';
 import EntityTable from 'app/shared/table/EntityTable';
-import { ENTITY_ACTION, ENTITY_TYPE } from 'app/config/constants';
+import { DEFAULT_ENTITY_SORT_FIELD, ENTITY_ACTION, ENTITY_TYPE } from 'app/config/constants';
 import EntityActionButton from 'app/shared/button/EntityActionButton';
 export interface IDrugProps extends StoreProps, RouteComponentProps<{ url: string }> {}
 
 export const Drug = (props: IDrugProps) => {
   const [search, setSearch] = useState('');
   const [paginationState, setPaginationState] = useState(
-    overridePaginationStateWithQueryParams(getSortState(props.location, ITEMS_PER_PAGE, 'id'), props.location.search)
+    overridePaginationStateWithQueryParams(
+      getSortState(props.location, ITEMS_PER_PAGE, DEFAULT_ENTITY_SORT_FIELD[ENTITY_TYPE.DRUG]),
+      props.location.search
+    )
   );
 
   const drugList = props.drugList;

--- a/src/main/webapp/app/entities/fda-submission/fda-submission.tsx
+++ b/src/main/webapp/app/entities/fda-submission/fda-submission.tsx
@@ -14,14 +14,17 @@ import _ from 'lodash';
 import { debouncedSearchWithPagination } from 'app/shared/util/pagination-crud-store';
 import { IFdaSubmission } from 'app/shared/model/fda-submission.model';
 import EntityTable from 'app/shared/table/EntityTable';
-import { ENTITY_ACTION, ENTITY_TYPE } from 'app/config/constants';
+import { DEFAULT_ENTITY_SORT_FIELD, ENTITY_ACTION, ENTITY_TYPE } from 'app/config/constants';
 import EntityActionButton from 'app/shared/button/EntityActionButton';
 export interface IFdaSubmissionProps extends StoreProps, RouteComponentProps<{ url: string }> {}
 
 export const FdaSubmission = (props: IFdaSubmissionProps) => {
   const [search, setSearch] = useState('');
   const [paginationState, setPaginationState] = useState(
-    overridePaginationStateWithQueryParams(getSortState(props.location, ITEMS_PER_PAGE, 'id'), props.location.search)
+    overridePaginationStateWithQueryParams(
+      getSortState(props.location, ITEMS_PER_PAGE, DEFAULT_ENTITY_SORT_FIELD[ENTITY_TYPE.FDA_SUBMISSION]),
+      props.location.search
+    )
   );
 
   const fdaSubmissionList = props.fdaSubmissionList;

--- a/src/main/webapp/app/entities/gene/gene.tsx
+++ b/src/main/webapp/app/entities/gene/gene.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'app/shared/util/typed-inject';
-import { Link, RouteComponentProps } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { Input, Col, Row } from 'reactstrap';
 import { getSortState, JhiPagination, JhiItemCount } from 'react-jhipster';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { IGene } from 'app/shared/model/gene.model';
 import { ASC, DESC, ITEMS_PER_PAGE, SORT } from 'app/shared/util/pagination.constants';
 import { overridePaginationStateWithQueryParams } from 'app/shared/util/entity-utils';
@@ -12,14 +11,17 @@ import { TableHeader } from 'app/shared/table/TableHeader';
 import { Column } from 'react-table';
 import { debouncedSearchWithPagination } from 'app/shared/util/pagination-crud-store';
 import EntityTable from 'app/shared/table/EntityTable';
-import { ENTITY_ACTION, ENTITY_TYPE } from 'app/config/constants';
+import { DEFAULT_ENTITY_SORT_FIELD, ENTITY_ACTION, ENTITY_TYPE } from 'app/config/constants';
 import EntityActionButton from 'app/shared/button/EntityActionButton';
 export interface IGeneProps extends StoreProps, RouteComponentProps<{ url: string }> {}
 
 export const Gene = (props: IGeneProps) => {
   const [search, setSearch] = useState('');
   const [paginationState, setPaginationState] = useState(
-    overridePaginationStateWithQueryParams(getSortState(props.location, ITEMS_PER_PAGE, 'id'), props.location.search)
+    overridePaginationStateWithQueryParams(
+      getSortState(props.location, ITEMS_PER_PAGE, DEFAULT_ENTITY_SORT_FIELD[ENTITY_TYPE.GENE]),
+      props.location.search
+    )
   );
 
   const geneList = props.geneList;

--- a/src/main/webapp/app/shared/select/DrugSelect.tsx
+++ b/src/main/webapp/app/shared/select/DrugSelect.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { Props as SelectProps } from 'react-select';
 import { AsyncPaginate } from 'react-select-async-paginate';
 import { defaultAdditional } from 'app/components/curationPanel/FdaSubmissionPanel';
-import { DEFAULT_SORT_PARAMETER, SearchOptionType } from 'app/config/constants';
+import { DEFAULT_ENTITY_SORT_FIELD, DEFAULT_SORT_DIRECTION, ENTITY_TYPE, SearchOptionType } from 'app/config/constants';
 import { IRootStore } from 'app/stores/createStore';
 import { connect } from '../util/typed-inject';
 import { IDrug } from '../model/drug.model';
 import { ITEMS_PER_PAGE } from '../util/pagination.constants';
+import { getEntityPaginationSortParameter } from '../util/entity-utils';
 
 interface IDrugSelectProps extends SelectProps, StoreProps {}
+
+const sortParamter = getEntityPaginationSortParameter(DEFAULT_ENTITY_SORT_FIELD[ENTITY_TYPE.DRUG], DEFAULT_SORT_DIRECTION);
 
 const DrugSelect: React.FunctionComponent<IDrugSelectProps> = props => {
   const { getDrugs, searchDrugs, ...selectProps } = props;
@@ -16,9 +19,9 @@ const DrugSelect: React.FunctionComponent<IDrugSelectProps> = props => {
     let result = undefined;
     let options = [];
     if (searchWord) {
-      result = await searchDrugs({ query: searchWord, page: page - 1, size: ITEMS_PER_PAGE, sort: DEFAULT_SORT_PARAMETER });
+      result = await searchDrugs({ query: searchWord, page: page - 1, size: ITEMS_PER_PAGE, sort: sortParamter });
     } else {
-      result = await getDrugs({ page: page - 1, size: ITEMS_PER_PAGE, sort: 'name,ASC' });
+      result = await getDrugs({ page: page - 1, size: ITEMS_PER_PAGE, sort: sortParamter });
     }
 
     options = result?.data?.map((entity: IDrug) => ({

--- a/src/main/webapp/app/shared/select/GeneSelect.tsx
+++ b/src/main/webapp/app/shared/select/GeneSelect.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import { Props as SelectProps } from 'react-select';
 import { AsyncPaginate } from 'react-select-async-paginate';
 import { defaultAdditional } from 'app/components/curationPanel/FdaSubmissionPanel';
-import { DEFAULT_SORT_PARAMETER, SearchOptionType } from 'app/config/constants';
+import { DEFAULT_ENTITY_SORT_FIELD, DEFAULT_SORT_DIRECTION, ENTITY_TYPE, SearchOptionType } from 'app/config/constants';
 import { IRootStore } from 'app/stores/createStore';
 import { connect } from '../util/typed-inject';
 import { IGene } from '../model/gene.model';
 import { ITEMS_PER_PAGE } from '../util/pagination.constants';
+import { getEntityPaginationSortParameter } from '../util/entity-utils';
 
 export interface IGeneSelectProps extends SelectProps, StoreProps {}
+
+const sortParamter = getEntityPaginationSortParameter(DEFAULT_ENTITY_SORT_FIELD[ENTITY_TYPE.GENE], DEFAULT_SORT_DIRECTION);
 
 const GeneSelect = (props: IGeneSelectProps) => {
   const { getGenes, searchGenes, ...selectProps } = props;
@@ -16,9 +19,9 @@ const GeneSelect = (props: IGeneSelectProps) => {
     let result = undefined;
     let options = [];
     if (searchWord) {
-      result = await searchGenes({ query: searchWord, page: page - 1, size: ITEMS_PER_PAGE, sort: DEFAULT_SORT_PARAMETER });
+      result = await searchGenes({ query: searchWord, page: page - 1, size: ITEMS_PER_PAGE, sort: sortParamter });
     } else {
-      result = await getGenes({ page: page - 1, size: ITEMS_PER_PAGE, sort: 'hugoSymbol,ASC' });
+      result = await getGenes({ page: page - 1, size: ITEMS_PER_PAGE, sort: sortParamter });
     }
 
     options = result?.data?.map((entity: IGene) => ({

--- a/src/main/webapp/app/shared/util/entity-utils.ts
+++ b/src/main/webapp/app/shared/util/entity-utils.ts
@@ -41,3 +41,7 @@ export const overridePaginationStateWithQueryParams = (paginationBaseState: IPag
   }
   return paginationBaseState;
 };
+
+export const getEntityPaginationSortParameter = (field: string, sortDirection: string) => {
+  return `${field},${sortDirection}`;
+};


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3148

- Added `SortToFieldSortBuilderConverter.java` to append '.keyword' field to sort parameter when the sort field is of type `String`. 

This fixes the error from ES when sorting by a text field: 
`...ElasticsearchException[Elasticsearch exception [type=illegal_argument_exception, reason=Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead...`

- Update GeneSelect to sort by `hugoSymbol,ASC` and DrugSelect to sort by `name,ASC` by default
- Update tables to sort by their default fields