### PR TITLE
Handle redis caching errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,7 +329,7 @@
         <dependency>
             <groupId>com.github.oncokb</groupId>
             <artifactId>oncokb-meta</artifactId>
-            <version>4f57f6d0fa</version>
+            <version>b2d8daff89</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>

--- a/src/main/java/org/mskcc/oncokb/transcript/config/cache/LoggingCacheErrorHandler.java
+++ b/src/main/java/org/mskcc/oncokb/transcript/config/cache/LoggingCacheErrorHandler.java
@@ -1,0 +1,42 @@
+package org.mskcc.oncokb.transcript.config.cache;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.Cache;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+
+/**
+ * Implementation of org.springframework.cache.interceptor.CacheErrorHandler
+ * that logs the error messages when performing Redis operations.
+ * Redis will throw a RuntimeException causing our APIs to return HTTP 500 responses, so we defined
+ * this class to just log the errors and allow our app fallback to the non-cached version.
+ */
+
+public class LoggingCacheErrorHandler implements CacheErrorHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LoggingCacheErrorHandler.class);
+
+    @Override
+    public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+        LOG.error(String.format("Cache '%s' failed to get entry with key '%s'", cache.getName(), key), exception);
+        exception.printStackTrace();
+    }
+
+    @Override
+    public void handleCachePutError(RuntimeException exception, Cache cache, Object key, Object value) {
+        LOG.error(String.format("Cache '%s' failed to put entry with key '%s'", cache.getName(), key), exception);
+        exception.printStackTrace();
+    }
+
+    @Override
+    public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+        LOG.error(String.format("Cache '%s' failed to evict entry with key '%s'", cache.getName(), key), exception);
+        exception.printStackTrace();
+    }
+
+    @Override
+    public void handleCacheClearError(RuntimeException exception, Cache cache) {
+        LOG.error(String.format("Cache '%s' failed to clear entries", cache.getName()), exception);
+        exception.printStackTrace();
+    }
+}


### PR DESCRIPTION
We will print all errors in log but let it silently skip so website functionality is not affected.

This is related to https://github.com/oncokb/oncokb/issues/3326