### PR TITLE
Fix firebase auth error

### DIFF
--- a/src/main/webapp/app/app.tsx
+++ b/src/main/webapp/app/app.tsx
@@ -31,9 +31,11 @@ const App: React.FunctionComponent<IAppProps> = (props: IAppProps) => {
   }, [props.isAuthenticated, props.isAuthorized, props.sidebarWidth]);
 
   useEffect(() => {
+    let authSubscriber = undefined;
     if (props.hasFirebaseAccess) {
-      props.initializeFirebase();
+      authSubscriber = props.initializeFirebase();
     }
+    return () => authSubscriber && authSubscriber();
   }, [props.hasFirebaseAccess]);
 
   return (

--- a/src/main/webapp/app/stores/authentication.store.ts
+++ b/src/main/webapp/app/stores/authentication.store.ts
@@ -90,6 +90,7 @@ export class AuthStore extends BaseStore {
   *logoutGen() {
     try {
       this.reset();
+      this.rootStore.firebaseStore.signOutFromFirebase();
       const result: AxiosResponse = yield axios.post('/api/logout', {});
       this.logoutUrl = result.data.logoutUrl;
       return result;


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3561

### Cause of issue
When the firebase custom token is minted in the backend, it has an expiration time of 1 hour. This means that our frontend application has 1 hour to use that token in the `signInWithCustomToken` method from `firebase/auth` library. 

1. When we refresh the page, we try to `initializeFirebase()` which ultimately calls the  `signInWithCustomToken()`. So, every time the page is refreshed, we try to use the custom token to sign in again. Since the custom token has an expiration of 1 hour, it cannot be used to sign in after 1 hour. 

2. The second way we can get this error is if the user has been idle for >30mins. By default, spring session has a max idle timeout of 30 minutes, so after that, it would try to get the user to relog. When this happens, the user is redirected to keycloak page and upon successful login, they are redirected back to the application. This process triggers a refresh.

### Solution
After we call `signInWithCustomToken`, Firebase SDK will handle refreshing the token for us. By default, firebase stores our user credentials inside `IndexDB` and use `LOCAL` persistence. ([Ref](https://firebase.google.com/docs/auth/web/auth-state-persistence#:~:text=firebase.auth.Auth.Persistence.LOCAL)) This means that the user should remain signed in even after page is refreshed, browser is closed, opens new tab until they are explicitly signed out.

![image](https://github.com/oncokb/oncokb-transcript/assets/59149377/7836ae19-c2d0-4a43-83d1-252bb4ebb30b)

All we have to do is create the listener `onAuthStateChanged` to only sign in with custom token when firebase cannot find the user credentials in `IndexDB`.


