### PR TITLE
Enable searching by hugoSymbol in curation gene list page

### DIFF
--- a/src/main/webapp/app/config/constants/constants.ts
+++ b/src/main/webapp/app/config/constants/constants.ts
@@ -9,6 +9,7 @@ export const messages = {
 };
 
 export const APP_DATE_FORMAT = 'DD/MM/YY HH:mm';
+export const APP_DATETIME_FORMAT = 'MM/DD/YYYY h:mm A';
 export const APP_TIMESTAMP_FORMAT = 'DD/MM/YY HH:mm:ss';
 export const APP_LOCAL_DATE_FORMAT = 'DD/MM/YYYY';
 export const APP_LOCAL_DATETIME_FORMAT = 'YYYY-MM-DDTHH:mm';

--- a/src/main/webapp/app/pages/curation/GeneListPage.tsx
+++ b/src/main/webapp/app/pages/curation/GeneListPage.tsx
@@ -6,10 +6,11 @@ import { If, Then, Else } from 'react-if';
 import LoadingIndicator, { LoaderSize } from 'app/oncokb-commons/components/loadingIndicator/LoadingIndicator';
 import { geneNeedsReview } from 'app/shared/util/firebase/firebase-utils';
 import _ from 'lodash';
-import { Column } from 'react-table';
 import { Link } from 'react-router-dom';
-import { PAGE_ROUTE } from 'app/config/constants/constants';
-import OncoKBTable from 'app/shared/table/OncoKBTable';
+import { APP_DATETIME_FORMAT, APP_DATE_FORMAT, PAGE_ROUTE } from 'app/config/constants/constants';
+import OncoKBTable, { SearchColumn } from 'app/shared/table/OncoKBTable';
+import { filterByKeyword } from 'app/shared/util/utils';
+import { TextFormat } from 'react-jhipster';
 
 type GeneMetaInfo = {
   hugoSymbol: string;
@@ -43,17 +44,21 @@ const GeneListPage = (props: StoreProps) => {
     }
   }, [props.metaData]);
 
-  const columns: Column<GeneMetaInfo>[] = [
+  const columns: SearchColumn<GeneMetaInfo>[] = [
     {
       accessor: 'hugoSymbol',
       Header: 'Hugo Symbol',
       Cell(cell: { value: string }): any {
         return <Link to={`${PAGE_ROUTE.CURATION}/${cell.value}`}>{cell.value}</Link>;
       },
+      onFilter: (data: GeneMetaInfo, keyword) => (data.hugoSymbol ? filterByKeyword(data.hugoSymbol, keyword) : false),
     },
     {
       accessor: 'lastModifiedAt',
       Header: 'Last modified at',
+      Cell(cell: { value: string }): any {
+        return cell.value ? <TextFormat value={new Date(parseInt(cell.value, 10))} type="date" format={APP_DATETIME_FORMAT} /> : '';
+      },
     },
     {
       accessor: 'lastModifiedBy',
@@ -73,7 +78,17 @@ const GeneListPage = (props: StoreProps) => {
       <Then>
         <Row>
           <Col>
-            <OncoKBTable data={geneMeta} columns={columns} showPagination />
+            <OncoKBTable
+              data={geneMeta}
+              columns={columns}
+              showPagination
+              defaultSorted={[
+                {
+                  id: 'needsReview',
+                  desc: true,
+                },
+              ]}
+            />
           </Col>
         </Row>
       </Then>


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3610

- Enable search by hugoSymbol
- Sort by needs review first
- Convert last modified by timestamp to a date
![image](https://github.com/oncokb/oncokb-transcript/assets/59149377/96c5b240-7ea3-472c-aae0-bcec9f7227c0)
