### PR TITLE
Add mutation and cancer type level summaries to Collapsible header

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "mobx-react": "^7.2.0",
     "oncokb-styles": "^1.5.0",
     "path-browserify": "1.0.1",
-    "rc-tooltip": "^5.1.1",
+    "rc-tooltip": "^6.1.2",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-firebase-hooks": "^5.1.1",

--- a/src/main/webapp/app/app.scss
+++ b/src/main/webapp/app/app.scss
@@ -356,3 +356,21 @@ http://stackoverflow.com/questions/23436430/bootstrap-3-input-group-100-width */
     }
   }
 }
+
+// Override rc-tooltip styles
+.rc-tooltip {
+  opacity: 1 !important;
+}
+
+// In rc-tooltip v6.1.2, there is a styling that causes the arrow to not be
+// in the middle. We are overriding the style here to fix that.
+.rc-tooltip-placement-top .rc-tooltip-arrow,
+.rc-tooltip-placement-topLeft .rc-tooltip-arrow,
+.rc-tooltip-placement-topRight .rc-tooltip-arrow {
+  transform: translate(0%, 5px) !important;
+}
+.rc-tooltip-placement-bottom .rc-tooltip-arrow,
+.rc-tooltip-placement-bottomLeft .rc-tooltip-arrow,
+.rc-tooltip-placement-bottomRight .rc-tooltip-arrow {
+  transform: translate(0%, -5px) !important;
+}

--- a/src/main/webapp/app/app.tsx
+++ b/src/main/webapp/app/app.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import 'react-toastify/dist/ReactToastify.css';
+import 'oncokb-styles/dist/oncokb.css';
 import './app.scss';
 import 'react-table/react-table.css';
 import { componentInject } from 'app/shared/util/typed-inject';

--- a/src/main/webapp/app/config/constants/firebase.ts
+++ b/src/main/webapp/app/config/constants/firebase.ts
@@ -1,5 +1,6 @@
-import { Gene, ONCOGENICITY } from 'app/shared/model/firebase/firebase.model';
+import { Gene, FIREBASE_ONCOGENICITY } from 'app/shared/model/firebase/firebase.model';
 import { ExtractPathExpressions } from 'app/shared/util/firebase/firebase-crud-store';
+import { ONCOGENICITY } from './constants';
 
 export enum GENE_TYPE {
   TUMOR_SUPPRESSOR = 'Tumor Suppressor',
@@ -33,10 +34,20 @@ export const FB_COLLECTION_PATH = {
   META_COLLABORATOR_GENE: `${FB_COLLECTION.META}/collaborators/:name/:index`,
 };
 
-export const ONCOGENICITY_CLASS_MAPPING: { [key in ONCOGENICITY]: string } = {
-  [ONCOGENICITY.YES]: 'oncogenic',
-  [ONCOGENICITY.LIKELY]: 'likely-oncogenic',
-  [ONCOGENICITY.RESISTANCE]: 'resistance',
-  [ONCOGENICITY.LIKELY_NEUTRAL]: 'likely-neutral',
-  [ONCOGENICITY.INCONCLUSIVE]: 'inconclusive',
+export const ONCOGENICITY_CLASS_MAPPING: { [key in FIREBASE_ONCOGENICITY]: string } = {
+  [FIREBASE_ONCOGENICITY.YES]: 'oncogenic',
+  [FIREBASE_ONCOGENICITY.LIKELY]: 'likely-oncogenic',
+  [FIREBASE_ONCOGENICITY.RESISTANCE]: 'resistance',
+  [FIREBASE_ONCOGENICITY.LIKELY_NEUTRAL]: 'likely-neutral',
+  [FIREBASE_ONCOGENICITY.INCONCLUSIVE]: 'inconclusive',
+  [FIREBASE_ONCOGENICITY.UNKNOWN]: 'unknown',
+};
+
+export const FIREBASE_ONCOGENICITY_MAPPING: { [key in FIREBASE_ONCOGENICITY]: string } = {
+  [FIREBASE_ONCOGENICITY.YES]: ONCOGENICITY.ONCOGENIC,
+  [FIREBASE_ONCOGENICITY.LIKELY]: ONCOGENICITY.LIKELY_ONCOGENIC,
+  [FIREBASE_ONCOGENICITY.LIKELY_NEUTRAL]: ONCOGENICITY.LIKELY_NEUTRAL,
+  [FIREBASE_ONCOGENICITY.RESISTANCE]: ONCOGENICITY.RESISTANCE,
+  [FIREBASE_ONCOGENICITY.UNKNOWN]: `${ONCOGENICITY.UNKNOWN} Oncogenic Effect`,
+  [FIREBASE_ONCOGENICITY.INCONCLUSIVE]: ONCOGENICITY.INCONCLUSIVE,
 };

--- a/src/main/webapp/app/config/constants/firebase.ts
+++ b/src/main/webapp/app/config/constants/firebase.ts
@@ -1,4 +1,4 @@
-import { Gene } from 'app/shared/model/firebase/firebase.model';
+import { Gene, ONCOGENICITY } from 'app/shared/model/firebase/firebase.model';
 import { ExtractPathExpressions } from 'app/shared/util/firebase/firebase-crud-store';
 
 export enum GENE_TYPE {
@@ -31,4 +31,12 @@ export const FB_COLLECTION_PATH = {
   META_COLLABORATORS: `${FB_COLLECTION.META}/collaborators`,
   META_COLLABORATOR: `${FB_COLLECTION.META}/collaborators/:name`,
   META_COLLABORATOR_GENE: `${FB_COLLECTION.META}/collaborators/:name/:index`,
+};
+
+export const ONCOGENICITY_CLASS_MAPPING: { [key in ONCOGENICITY]: string } = {
+  [ONCOGENICITY.YES]: 'oncogenic',
+  [ONCOGENICITY.LIKELY]: 'likely-oncogenic',
+  [ONCOGENICITY.RESISTANCE]: 'resistance',
+  [ONCOGENICITY.LIKELY_NEUTRAL]: 'likely-neutral',
+  [ONCOGENICITY.INCONCLUSIVE]: 'inconclusive',
 };

--- a/src/main/webapp/app/pages/curation/CurationPage.tsx
+++ b/src/main/webapp/app/pages/curation/CurationPage.tsx
@@ -24,9 +24,12 @@ import { getFirebasePath, getMutationName, getTxName } from 'app/shared/util/fir
 import Collapsible, { NestLevelType } from 'app/pages/curation/collapsible/Collapsible';
 import styles from './styles.module.scss';
 import { notifyError } from 'app/oncokb-commons/components/util/NotificationUtils';
-import { ONCOGENICITY, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
+import { FIREBASE_ONCOGENICITY, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
 import RealtimeDropdownInput from 'app/shared/firebase/input/RealtimeDropdownInput';
 import { GENE_TYPE, GENE_TYPE_KEY } from 'app/config/constants/firebase';
+import DefaultTooltip from 'app/shared/tooltip/DefaultTooltip';
+import classNames from 'classnames';
+import { FaAccessibleIcon } from 'react-icons/fa';
 
 export interface ICurationPageProps extends StoreProps, RouteComponentProps<{ hugoSymbol: string }> {}
 
@@ -184,11 +187,11 @@ const CurationPage = (props: ICurationPageProps) => {
                           groupHeader="Oncogenic"
                           isRadio
                           options={[
-                            ONCOGENICITY.YES,
-                            ONCOGENICITY.LIKELY,
-                            ONCOGENICITY.LIKELY_NEUTRAL,
-                            ONCOGENICITY.INCONCLUSIVE,
-                            ONCOGENICITY.RESISTANCE,
+                            FIREBASE_ONCOGENICITY.YES,
+                            FIREBASE_ONCOGENICITY.LIKELY,
+                            FIREBASE_ONCOGENICITY.LIKELY_NEUTRAL,
+                            FIREBASE_ONCOGENICITY.INCONCLUSIVE,
+                            FIREBASE_ONCOGENICITY.RESISTANCE,
                           ].map(label => ({
                             label,
                             fieldKey: `mutations/${mutationIndex}/mutation_effect/oncogenic`,

--- a/src/main/webapp/app/pages/curation/CurationPage.tsx
+++ b/src/main/webapp/app/pages/curation/CurationPage.tsx
@@ -21,7 +21,7 @@ import WithSeparator from 'react-with-separator';
 import { AutoParseRefField } from 'app/shared/form/AutoParseRefField';
 import { RealtimeCheckedInputGroup, RealtimeTextAreaInput } from 'app/shared/firebase/input/FirebaseRealtimeInput';
 import { getFirebasePath, getMutationName, getTxName } from 'app/shared/util/firebase/firebase-utils';
-import Collapsible, { NestLevel } from 'app/pages/curation/collapsible/Collapsible';
+import Collapsible, { NestLevelType } from 'app/pages/curation/collapsible/Collapsible';
 import styles from './styles.module.scss';
 import { notifyError } from 'app/oncokb-commons/components/util/NotificationUtils';
 import { ONCOGENICITY, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
@@ -146,9 +146,14 @@ const CurationPage = (props: ICurationPageProps) => {
             .map((mutation, mutationIndex) => (
               <Row key={mutationIndex} className={'mb-2'}>
                 <Col>
-                  <Collapsible nestLevel={NestLevel.MUTATION} className={'mb-1'} title={`Mutation: ${getMutationName(mutation)}`}>
-                    <Collapsible nestLevel={NestLevel.MUTATION_EFFECT} title={'Mutation Effect'}>
-                      <Collapsible nestLevel={NestLevel.BIOLOGICAL_EFFECT} title={'Biological Effect'}>
+                  <Collapsible
+                    nestLevel={NestLevelType.MUTATION}
+                    className={'mb-1'}
+                    title={`Mutation: ${getMutationName(mutation)}`}
+                    mutationUuid={mutation.name_uuid}
+                  >
+                    <Collapsible nestLevel={NestLevelType.MUTATION_EFFECT} title={'Mutation Effect'}>
+                      <Collapsible nestLevel={NestLevelType.BIOLOGICAL_EFFECT} title={'Biological Effect'}>
                         <RealtimeCheckedInputGroup
                           groupHeader="Mutation Effect"
                           isRadio
@@ -174,7 +179,7 @@ const CurationPage = (props: ICurationPageProps) => {
                           name="description"
                         />
                       </Collapsible>
-                      <Collapsible nestLevel={NestLevel.SOMATIC} className={'mt-2'} title={'Somatic'}>
+                      <Collapsible nestLevel={NestLevelType.SOMATIC} className={'mt-2'} title={'Somatic'}>
                         <RealtimeCheckedInputGroup
                           groupHeader="Oncogenic"
                           isRadio
@@ -191,7 +196,7 @@ const CurationPage = (props: ICurationPageProps) => {
                         />
                       </Collapsible>
                       {mutation.mutation_effect.germline && (
-                        <Collapsible nestLevel={NestLevel.GERMLINE} className={'mt-2'} title={'Germline'}>
+                        <Collapsible nestLevel={NestLevelType.GERMLINE} className={'mt-2'} title={'Germline'}>
                           <RealtimeCheckedInputGroup
                             groupHeader="Pathogenic"
                             isRadio
@@ -235,8 +240,10 @@ const CurationPage = (props: ICurationPageProps) => {
                       mutation.tumors.map((tumor, tumorIndex) => (
                         <Collapsible
                           className={'mt-2'}
+                          mutationUuid={mutation.name_uuid}
+                          cancerTypeUuid={tumor.cancerTypes_uuid}
                           key={tumor.cancerTypes_uuid}
-                          nestLevel={NestLevel.CANCER_TYPE}
+                          nestLevel={NestLevelType.CANCER_TYPE}
                           title={`Cancer Type: ${tumor.cancerTypes.map(cancerType => getCancerTypeName(cancerType)).join(', ')}`}
                         >
                           <RealtimeTextAreaInput
@@ -255,7 +262,7 @@ const CurationPage = (props: ICurationPageProps) => {
                                   <Collapsible
                                     className={'mt-2'}
                                     key={tumor.cancerTypes_uuid}
-                                    nestLevel={NestLevel.THERAPY}
+                                    nestLevel={NestLevelType.THERAPY}
                                     title={`Therapy: ${getTxName(props.drugList, treatment.name)}`}
                                   >
                                     <RealtimeDropdownInput
@@ -316,6 +323,7 @@ const mapStoreToProps = ({ geneStore, firebaseGeneStore, firebaseMetaStore, fire
   addListener: firebaseGeneStore.addListener,
   data: firebaseGeneStore.data,
   update: firebaseGeneStore.update,
+  nestLevelSummary: firebaseGeneStore.mutationSummaryStats,
   updateReviewableContent: firebaseGeneStore.updateReviewableContent,
   addMetaCollaboratorsListener: firebaseMetaStore.addMetaCollaboratorsListener,
   metaData: firebaseMetaStore.data,

--- a/src/main/webapp/app/pages/curation/CurationPage.tsx
+++ b/src/main/webapp/app/pages/curation/CurationPage.tsx
@@ -323,7 +323,6 @@ const mapStoreToProps = ({ geneStore, firebaseGeneStore, firebaseMetaStore, fire
   addListener: firebaseGeneStore.addListener,
   data: firebaseGeneStore.data,
   update: firebaseGeneStore.update,
-  nestLevelSummary: firebaseGeneStore.mutationSummaryStats,
   updateReviewableContent: firebaseGeneStore.updateReviewableContent,
   addMetaCollaboratorsListener: firebaseMetaStore.addMetaCollaboratorsListener,
   metaData: firebaseMetaStore.data,

--- a/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
@@ -4,30 +4,51 @@ import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons
 import classnames from 'classnames';
 import { LEVELS } from 'app/config/colors';
 import styles from './styles.module.scss';
+import MutationLevelSummary from '../nestLevelSummary/MutationLevelSummary';
+import CancerTypeLevelSummary from '../nestLevelSummary/CancerTypeLevelSummary';
 
 interface IProps {
   title: string;
-  nestLevel: NestLevel;
+  mutationUuid?: string;
+  cancerTypeUuid?: string;
+  nestLevel: NestLevelType;
   open?: boolean;
   className?: string;
 }
-export enum NestLevel {
-  MUTATION = '1',
-  MUTATION_EFFECT = '2',
-  SOMATIC = '3',
-  GERMLINE = '3',
-  CANCER_TYPE = '2',
-  BIOLOGICAL_EFFECT = '3',
-  THERAPY = '3',
+
+export enum NestLevelType {
+  MUTATION,
+  MUTATION_EFFECT,
+  SOMATIC,
+  GERMLINE,
+  CANCER_TYPE,
+  BIOLOGICAL_EFFECT,
+  THERAPY,
 }
 
-const NestLevelColor: { [keys in NestLevel]: string } = {
-  '1': LEVELS['1'],
-  '2': LEVELS['2'],
-  '3': LEVELS['3'],
+export const NestLevelMapping: { [key in NestLevelType]: string } = {
+  [NestLevelType.MUTATION]: '1',
+  [NestLevelType.MUTATION_EFFECT]: '2',
+  [NestLevelType.SOMATIC]: '3',
+  [NestLevelType.GERMLINE]: '3',
+  [NestLevelType.CANCER_TYPE]: '2',
+  [NestLevelType.BIOLOGICAL_EFFECT]: '3',
+  [NestLevelType.THERAPY]: '3',
 };
 
-const Collapsible: React.FunctionComponent<IProps> = ({ open, children, title, className, nestLevel }) => {
+export enum NestLevel {
+  LEVEL_1 = '1',
+  LEVEL_2 = '2',
+  LEVEL_3 = '3',
+}
+
+const NestLevelColor: { [key in NestLevel]: string } = {
+  [NestLevel.LEVEL_1]: LEVELS['1'],
+  [NestLevel.LEVEL_2]: LEVELS['2'],
+  [NestLevel.LEVEL_3]: LEVELS['3'],
+};
+
+const Collapsible: React.FunctionComponent<IProps> = ({ open, children, title, className, nestLevel, mutationUuid, cancerTypeUuid }) => {
   const [isOpen, setIsOpen] = useState(open);
 
   const handleFilterOpening = () => {
@@ -41,7 +62,7 @@ const Collapsible: React.FunctionComponent<IProps> = ({ open, children, title, c
           className={classnames('card-header d-flex align-items-center border border-light p-1 bg-transparent', styles.header)}
           ref={node => {
             if (node) {
-              node.style.setProperty('border-left-color', NestLevelColor[nestLevel], 'important');
+              node.style.setProperty('border-left-color', NestLevelColor[NestLevelMapping[nestLevel]], 'important');
             }
           }}
         >
@@ -49,6 +70,10 @@ const Collapsible: React.FunctionComponent<IProps> = ({ open, children, title, c
             {isOpen ? <FontAwesomeIcon icon={faChevronDown} size={'sm'} /> : <FontAwesomeIcon icon={faChevronRight} size={'sm'} />}
           </button>
           <span className="font-weight-bold font-weight-bold">{title}</span>
+          {nestLevel === NestLevelType.MUTATION ? <MutationLevelSummary mutationUuid={mutationUuid} /> : undefined}
+          {nestLevel === NestLevelType.CANCER_TYPE ? (
+            <CancerTypeLevelSummary mutationUuid={mutationUuid} cancerTypeUuid={cancerTypeUuid} />
+          ) : undefined}
         </div>
         {isOpen && <div className={classnames('card-body', styles.body)}>{children}</div>}
       </div>

--- a/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
@@ -6,6 +6,7 @@ import { LEVELS } from 'app/config/colors';
 import styles from './styles.module.scss';
 import MutationLevelSummary from '../nestLevelSummary/MutationLevelSummary';
 import CancerTypeLevelSummary from '../nestLevelSummary/CancerTypeLevelSummary';
+import NestLevelSummary from '../nestLevelSummary/NestLevelSummary';
 
 interface IProps {
   title: string;
@@ -55,6 +56,8 @@ const Collapsible: React.FunctionComponent<IProps> = ({ open, children, title, c
     setIsOpen(prev => !prev);
   };
 
+  const showMutationLevelSummary = nestLevel === NestLevelType.MUTATION && !title.includes(',');
+
   return (
     <>
       <div className={classnames('card', className, styles.main)}>
@@ -70,7 +73,7 @@ const Collapsible: React.FunctionComponent<IProps> = ({ open, children, title, c
             {isOpen ? <FontAwesomeIcon icon={faChevronDown} size={'sm'} /> : <FontAwesomeIcon icon={faChevronRight} size={'sm'} />}
           </button>
           <span className="font-weight-bold font-weight-bold">{title}</span>
-          {nestLevel === NestLevelType.MUTATION ? <MutationLevelSummary mutationUuid={mutationUuid} /> : undefined}
+          {showMutationLevelSummary ? <MutationLevelSummary mutationUuid={mutationUuid} /> : undefined}
           {nestLevel === NestLevelType.CANCER_TYPE ? (
             <CancerTypeLevelSummary mutationUuid={mutationUuid} cancerTypeUuid={cancerTypeUuid} />
           ) : undefined}

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/CancerTypeLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/CancerTypeLevelSummary.tsx
@@ -1,0 +1,37 @@
+import { componentInject } from 'app/shared/util/typed-inject';
+import { IRootStore } from 'app/stores';
+import { AllLevelSummary } from 'app/stores/firebase/firebase.gene.store';
+import _ from 'lodash';
+import { observer } from 'mobx-react';
+import React, { useMemo } from 'react';
+import NestLevelSummary from './NestLevelSummary';
+
+export interface CancerTypeLevelSummaryProps extends StoreProps {
+  mutationUuid: string;
+  cancerTypeUuid: string;
+}
+
+const CancerTypeLevelSummary = (props: CancerTypeLevelSummaryProps) => {
+  const summaryStats = useMemo(() => {
+    const stats = props.mutationSummaryStats[props.mutationUuid][props.cancerTypeUuid];
+    const { TT, oncogenicity, ...rest } = stats;
+    return {
+      ...rest,
+      txLevels: _.chain(stats.txLevels).countBy().value(),
+      dxLevels: _.chain(stats.dxLevels).countBy().value(),
+      pxLevels: _.chain(stats.pxLevels).countBy().value(),
+    };
+  }, [props.mutationSummaryStats, props.mutationUuid, props.cancerTypeUuid]);
+
+  return <NestLevelSummary summaryStats={summaryStats} />;
+};
+
+const mapStoreToProps = ({ firebaseGeneStore }: IRootStore) => ({
+  mutationSummaryStats: firebaseGeneStore.mutationSummaryStats,
+});
+
+type StoreProps = {
+  mutationSummaryStats?: AllLevelSummary;
+};
+
+export default componentInject(mapStoreToProps)(observer(CancerTypeLevelSummary));

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/MutationLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/MutationLevelSummary.tsx
@@ -1,0 +1,50 @@
+import { componentInject } from 'app/shared/util/typed-inject';
+import { IRootStore } from 'app/stores';
+import { AllLevelSummary } from 'app/stores/firebase/firebase.gene.store';
+import _ from 'lodash';
+import { observer } from 'mobx-react';
+import React, { useMemo } from 'react';
+import NestLevelSummary from './NestLevelSummary';
+
+export interface MutationLevelSummaryProps extends StoreProps {
+  mutationUuid: string;
+}
+
+const MutationLevelSummary = (props: MutationLevelSummaryProps) => {
+  const summaryStats = props.mutationSummaryStats[props.mutationUuid];
+
+  const mutationLevelSummary = useMemo(() => {
+    if (summaryStats) {
+      const cancerTypeLevelSummaries = Object.keys(summaryStats).map(mutation => summaryStats[mutation]);
+      const mutLevelSummary = {
+        oncogenicity: cancerTypeLevelSummaries[0]?.oncogenicity,
+        TT: _.sumBy(cancerTypeLevelSummaries, 'TT'),
+        TTS: _.sumBy(cancerTypeLevelSummaries, 'TTS'),
+        DxS: _.sumBy(cancerTypeLevelSummaries, 'DxS'),
+        PxS: _.sumBy(cancerTypeLevelSummaries, 'PxS'),
+        txLevels: _.chain(_.flatten(cancerTypeLevelSummaries.map(t => t.txLevels)))
+          .countBy()
+          .value(),
+        dxLevels: _.chain(_.flatten(cancerTypeLevelSummaries.map(t => t.dxLevels)))
+          .countBy()
+          .value(),
+        pxLevels: _.chain(_.flatten(cancerTypeLevelSummaries.map(t => t.pxLevels)))
+          .countBy()
+          .value(),
+      };
+      return mutLevelSummary;
+    }
+  }, [summaryStats]);
+
+  return <NestLevelSummary summaryStats={mutationLevelSummary} />;
+};
+
+const mapStoreToProps = ({ firebaseGeneStore }: IRootStore) => ({
+  mutationSummaryStats: firebaseGeneStore.mutationSummaryStats,
+});
+
+type StoreProps = {
+  mutationSummaryStats?: AllLevelSummary;
+};
+
+export default componentInject(mapStoreToProps)(observer(MutationLevelSummary));

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/MutationLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/MutationLevelSummary.tsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import { observer } from 'mobx-react';
 import React, { useMemo } from 'react';
 import NestLevelSummary from './NestLevelSummary';
+import { ONCOGENICITY } from 'app/config/constants/constants';
 
 export interface MutationLevelSummaryProps extends StoreProps {
   mutationUuid: string;
@@ -17,7 +18,7 @@ const MutationLevelSummary = (props: MutationLevelSummaryProps) => {
     if (summaryStats) {
       const cancerTypeLevelSummaries = Object.keys(summaryStats).map(mutation => summaryStats[mutation]);
       const mutLevelSummary = {
-        oncogenicity: cancerTypeLevelSummaries[0]?.oncogenicity,
+        oncogenicity: cancerTypeLevelSummaries[0]?.oncogenicity || ONCOGENICITY.UNKNOWN,
         TT: _.sumBy(cancerTypeLevelSummaries, 'TT'),
         TTS: _.sumBy(cancerTypeLevelSummaries, 'TTS'),
         DxS: _.sumBy(cancerTypeLevelSummaries, 'DxS'),

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
@@ -61,11 +61,7 @@ export const NestLevelSummary = (props: NestLevelSummaryProps) => {
             hideWhenOne
             count={1}
             base={
-              <DefaultTooltip
-                placement="top"
-                showArrow={false}
-                overlay={<span>{FIREBASE_ONCOGENICITY_MAPPING[props.summaryStats.oncogenicity]}</span>}
-              >
+              <DefaultTooltip placement="top" overlay={<span>{FIREBASE_ONCOGENICITY_MAPPING[props.summaryStats.oncogenicity]}</span>}>
                 <span className={classNames('oncokb', 'icon', `${ONCOGENICITY_CLASS_MAPPING[props.summaryStats.oncogenicity]}`)}></span>
               </DefaultTooltip>
             }

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
@@ -1,5 +1,6 @@
-import { ONCOGENICITY_CLASS_MAPPING } from 'app/config/constants/firebase';
+import { FIREBASE_ONCOGENICITY_MAPPING, ONCOGENICITY_CLASS_MAPPING } from 'app/config/constants/firebase';
 import CountBadge from 'app/shared/badge/CountBadge';
+import DefaultTooltip from 'app/shared/tooltip/DefaultTooltip';
 import classNames from 'classnames';
 import _ from 'lodash';
 import React from 'react';
@@ -23,13 +24,6 @@ export const NestLevelSummary = (props: NestLevelSummaryProps) => {
   if (props.summaryStats) {
     return (
       <div className="ml-auto d-flex flex-wrap">
-        {props.summaryStats.oncogenicity ? (
-          <CountBadge
-            hideWhenOne
-            count={1}
-            base={<span className={classNames('oncokb', 'icon', `${ONCOGENICITY_CLASS_MAPPING[props.summaryStats.oncogenicity]}`)}></span>}
-          />
-        ) : undefined}
         {Object.keys(props.summaryStats)
           .filter(k => props.summaryStats[k] && props.summaryStats[k] > 0)
           .map(k => {
@@ -62,6 +56,21 @@ export const NestLevelSummary = (props: NestLevelSummaryProps) => {
             />
           );
         })}
+        {props.summaryStats.oncogenicity ? (
+          <CountBadge
+            hideWhenOne
+            count={1}
+            base={
+              <DefaultTooltip
+                placement="top"
+                showArrow={false}
+                overlay={<span>{FIREBASE_ONCOGENICITY_MAPPING[props.summaryStats.oncogenicity]}</span>}
+              >
+                <span className={classNames('oncokb', 'icon', `${ONCOGENICITY_CLASS_MAPPING[props.summaryStats.oncogenicity]}`)}></span>
+              </DefaultTooltip>
+            }
+          />
+        ) : undefined}
       </div>
     );
   }

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
@@ -1,0 +1,71 @@
+import { ONCOGENICITY_CLASS_MAPPING } from 'app/config/constants/firebase';
+import CountBadge from 'app/shared/badge/CountBadge';
+import classNames from 'classnames';
+import _ from 'lodash';
+import React from 'react';
+
+export type NestLevelSummaryStats = {
+  TT?: number;
+  oncogenicity?: string;
+  TTS: number;
+  DxS: number;
+  PxS: number;
+  txLevels: any;
+  dxLevels: any;
+  pxLevels: any;
+};
+
+export interface NestLevelSummaryProps {
+  summaryStats: NestLevelSummaryStats;
+}
+
+export const NestLevelSummary = (props: NestLevelSummaryProps) => {
+  if (props.summaryStats) {
+    return (
+      <div className="ml-auto d-flex flex-wrap">
+        {props.summaryStats.oncogenicity ? (
+          <CountBadge
+            hideWhenOne
+            count={1}
+            base={<span className={classNames('oncokb', 'icon', `${ONCOGENICITY_CLASS_MAPPING[props.summaryStats.oncogenicity]}`)}></span>}
+          />
+        ) : undefined}
+        {Object.keys(props.summaryStats)
+          .filter(k => props.summaryStats[k] && props.summaryStats[k] > 0)
+          .map(k => {
+            return <CountBadge count={props.summaryStats[k]} base={k} key={`summaries-${k}`} />;
+          })}
+        {Object.keys(props.summaryStats.txLevels).map(k => {
+          return (
+            <CountBadge
+              count={props.summaryStats.txLevels[k]}
+              base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
+              key={`tx-levels-${k}`}
+            />
+          );
+        })}
+        {Object.keys(props.summaryStats.dxLevels).map(k => {
+          return (
+            <CountBadge
+              count={props.summaryStats.dxLevels[k]}
+              base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
+              key={`dx-levels-${k}`}
+            />
+          );
+        })}
+        {Object.keys(props.summaryStats.pxLevels).map(k => {
+          return (
+            <CountBadge
+              count={props.summaryStats.pxLevels[k]}
+              base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
+              key={`px-levels-${k}`}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+  return <div></div>;
+};
+
+export default NestLevelSummary;

--- a/src/main/webapp/app/shared/badge/CountBadge.tsx
+++ b/src/main/webapp/app/shared/badge/CountBadge.tsx
@@ -15,7 +15,7 @@ const CountBadge = (props: CountBadgeProps) => {
 
   return (
     <div className="mr-1">
-      <div className={classNames('pt-2', hideWhenOne ? 'pr-0' : 'pr-2', 'count-badge-wrapper')}>
+      <div className={classNames('pt-2', 'pr-2', 'count-badge-wrapper')}>
         <span className="font-weight-bold">{props.base}</span>
         {hideWhenOne ? undefined : (
           <span className="count-badge">

--- a/src/main/webapp/app/shared/badge/CountBadge.tsx
+++ b/src/main/webapp/app/shared/badge/CountBadge.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import './count-badge.scss';
+import classNames from 'classnames';
+
+export interface CountBadgeProps {
+  base: string | JSX.Element;
+  count: number;
+  hideWhenOne?: boolean;
+  max?: number;
+}
+
+const CountBadge = (props: CountBadgeProps) => {
+  const count = props.count > (props.max || Number.MAX_SAFE_INTEGER) ? `${props.max}+` : props.count;
+  const hideWhenOne = props.hideWhenOne !== undefined ? props.hideWhenOne : false;
+
+  return (
+    <div className="mr-1">
+      <div className={classNames('pt-2', hideWhenOne ? 'pr-0' : 'pr-2', 'count-badge-wrapper')}>
+        <span className="font-weight-bold">{props.base}</span>
+        {hideWhenOne ? undefined : (
+          <span className="count-badge">
+            <span className="badge rounded-pill bg-info text-white count-badge-content">{count}</span>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CountBadge;

--- a/src/main/webapp/app/shared/badge/count-badge.scss
+++ b/src/main/webapp/app/shared/badge/count-badge.scss
@@ -1,0 +1,25 @@
+.oncokb.icon {
+  margin: 0;
+}
+
+.count-badge-wrapper {
+  font-size: 90%;
+  position: relative;
+  display: flex;
+  align-items: center;
+  align-content: center;
+  height: 100%;
+}
+
+.count-badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  font-size: 75%;
+
+  .count-badge-content {
+    border: 1.5px solid white;
+    padding: 0.2rem;
+    line-height: 0.5;
+  }
+}

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -16,12 +16,13 @@ export type DrugCollection = {
   [hugoSymbol: string]: Drug;
 };
 
-export enum ONCOGENICITY {
+export enum FIREBASE_ONCOGENICITY {
   YES = 'Yes',
   LIKELY = 'Likely',
   LIKELY_NEUTRAL = 'Likely Neutral',
   INCONCLUSIVE = 'Inconclusive',
   RESISTANCE = 'Resistance',
+  UNKNOWN = 'Unknown',
 }
 
 export enum TX_LEVELS {
@@ -160,7 +161,7 @@ export class MutationEffect {
   effect = '';
   effect_review?: Review;
   effect_uuid: string = generateUuid();
-  oncogenic: ONCOGENICITY | '' = '';
+  oncogenic: FIREBASE_ONCOGENICITY | '' = '';
   oncogenic_review?: Review;
   oncogenic_uuid: string = generateUuid();
   germline?: GermlineMutation = new GermlineMutation();

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -160,7 +160,7 @@ export class MutationEffect {
   effect = '';
   effect_review?: Review;
   effect_uuid: string = generateUuid();
-  oncogenic = '';
+  oncogenic: ONCOGENICITY | '' = '';
   oncogenic_review?: Review;
   oncogenic_uuid: string = generateUuid();
   germline?: GermlineMutation = new GermlineMutation();

--- a/src/main/webapp/app/stores/firebase/firebase.gene.store.ts
+++ b/src/main/webapp/app/stores/firebase/firebase.gene.store.ts
@@ -1,4 +1,4 @@
-import { DX_LEVELS, Gene, ONCOGENICITY, PX_LEVELS, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
+import { DX_LEVELS, Gene, FIREBASE_ONCOGENICITY, PX_LEVELS, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
 import { IRootStore } from '../createStore';
 import { FirebaseReviewableCrudStore } from 'app/shared/util/firebase/firebase-reviewable-crud-store';
 import { ExtractPathExpressions } from 'app/shared/util/firebase/firebase-crud-store';
@@ -9,7 +9,7 @@ export type AllLevelSummary = {
   [mutationUuid: string]: {
     [cancerTypesUuid: string]: {
       TT: number;
-      oncogenicity: ONCOGENICITY | '';
+      oncogenicity: FIREBASE_ONCOGENICITY | '';
       TTS: number;
       DxS: number;
       PxS: number;

--- a/src/main/webapp/app/stores/firebase/firebase.gene.store.ts
+++ b/src/main/webapp/app/stores/firebase/firebase.gene.store.ts
@@ -1,12 +1,80 @@
-import { Gene } from 'app/shared/model/firebase/firebase.model';
+import { DX_LEVELS, Gene, ONCOGENICITY, PX_LEVELS, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
 import { IRootStore } from '../createStore';
 import { FirebaseReviewableCrudStore } from 'app/shared/util/firebase/firebase-reviewable-crud-store';
 import { ExtractPathExpressions } from 'app/shared/util/firebase/firebase-crud-store';
 import { notifyError } from 'app/oncokb-commons/components/util/NotificationUtils';
+import { computed, makeObservable } from 'mobx';
+
+export type AllLevelSummary = {
+  [mutationUuid: string]: {
+    [cancerTypesUuid: string]: {
+      TT: number;
+      oncogenicity: ONCOGENICITY | '';
+      TTS: number;
+      DxS: number;
+      PxS: number;
+      txLevels: TX_LEVELS[];
+      dxLevels: DX_LEVELS[];
+      pxLevels: PX_LEVELS[];
+    };
+  };
+};
 
 export class FirebaseGeneStore extends FirebaseReviewableCrudStore<Gene> {
   constructor(rootStore: IRootStore) {
     super(rootStore);
+    makeObservable(this, {
+      mutationSummaryStats: computed,
+    });
+  }
+
+  get mutationSummaryStats() {
+    const summary: AllLevelSummary = {};
+    const mutations = this.data?.mutations;
+    if (mutations) {
+      mutations.forEach(mutation => {
+        summary[mutation.name_uuid] = {};
+        if (mutation.tumors) {
+          mutation.tumors.forEach(tumor => {
+            summary[mutation.name_uuid][tumor.cancerTypes_uuid] = {
+              TT: 0,
+              oncogenicity: '',
+              TTS: 0,
+              DxS: 0,
+              PxS: 0,
+              txLevels: [],
+              dxLevels: [],
+              pxLevels: [],
+            };
+            summary[mutation.name_uuid][tumor.cancerTypes_uuid].TT++;
+            summary[mutation.name_uuid][tumor.cancerTypes_uuid].oncogenicity = mutation.mutation_effect.oncogenic;
+            if (tumor.summary) {
+              summary[mutation.name_uuid][tumor.cancerTypes_uuid].TTS++;
+            }
+            if (tumor.diagnosticSummary) {
+              summary[mutation.name_uuid][tumor.cancerTypes_uuid].DxS++;
+            }
+            if (tumor.prognosticSummary) {
+              summary[mutation.name_uuid][tumor.cancerTypes_uuid].PxS++;
+            }
+            tumor.TIs.forEach(ti => {
+              if (ti.treatments) {
+                ti.treatments.forEach(treatment => {
+                  summary[mutation.name_uuid][tumor.cancerTypes_uuid].txLevels.push(treatment.level);
+                });
+              }
+            });
+            if (tumor?.diagnostic?.level) {
+              summary[mutation.name_uuid][tumor.cancerTypes_uuid].dxLevels.push(tumor.diagnostic.level as DX_LEVELS);
+            }
+            if (tumor?.prognostic?.level) {
+              summary[mutation.name_uuid][tumor.cancerTypes_uuid].pxLevels.push(tumor.prognostic.level as PX_LEVELS);
+            }
+          });
+        }
+      });
+    }
+    return summary;
   }
 
   override updateReviewableContent(path: string, key: ExtractPathExpressions<Gene>, value: any) {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -68,12 +68,7 @@ module.exports = async options => {
           },
           {
             test: /\.(jpe?g|png|gif|svg|woff2?|otf|ttf|eot|ppt|pdf|zip)$/i,
-            loader: 'file-loader',
-            options: {
-              digest: 'hex',
-              hash: 'sha512',
-              name: 'content/[name].[ext]',
-            },
+            type: 'asset/resource',
           },
           /*
        ,


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3606

Here are some examples of how it looks like:
![image](https://github.com/oncokb/oncokb-transcript/assets/59149377/1c74b92f-75ef-454b-abe3-89e4c9a551ad)

![image](https://github.com/oncokb/oncokb-transcript/assets/59149377/8083d1de-6d88-4f30-8094-bae2fbda16fc)
