### PR TITLE
Add feature to delete mutation, cancer type and treatments in curation page

### DIFF
--- a/src/main/webapp/app/config/constants/firebase.ts
+++ b/src/main/webapp/app/config/constants/firebase.ts
@@ -27,6 +27,7 @@ export const FB_COLLECTION_PATH = {
   GENE: `${FB_COLLECTION.GENES}/:hugoSymbol`,
   MUTATIONS: `${FB_COLLECTION.GENES}/:hugoSymbol/mutations/:index`,
   TUMORS: `${FB_COLLECTION.GENES}/:hugoSymbol/mutations/:index/tumors/:index`,
+  TREATMENTS: `${FB_COLLECTION.GENES}/:hugoSymbol/mutations/:index/tumors/:index/TIs/:index/treatments/:index`,
   META_GENE: `${FB_COLLECTION.META}/:hugoSymbol`,
   META_GENE_REVIEW: `${FB_COLLECTION.META}/:hugoSymbol/review/:uuid`,
   META_COLLABORATORS: `${FB_COLLECTION.META}/collaborators`,

--- a/src/main/webapp/app/pages/curation/CurationPage.tsx
+++ b/src/main/webapp/app/pages/curation/CurationPage.tsx
@@ -155,7 +155,21 @@ const CurationPage = (props: ICurationPageProps) => {
                     firebasePath={getFirebasePath('MUTATIONS', hugoSymbol, mutationIndex)}
                   >
                     <Collapsible nestLevel={NestLevelType.MUTATION_EFFECT} title={'Mutation Effect'}>
-                      <Collapsible nestLevel={NestLevelType.BIOLOGICAL_EFFECT} title={'Biological Effect'}>
+                      <Collapsible nestLevel={NestLevelType.SOMATIC} title={'Somatic'}>
+                        <RealtimeCheckedInputGroup
+                          groupHeader="Oncogenic"
+                          isRadio
+                          options={[
+                            FIREBASE_ONCOGENICITY.YES,
+                            FIREBASE_ONCOGENICITY.LIKELY,
+                            FIREBASE_ONCOGENICITY.LIKELY_NEUTRAL,
+                            FIREBASE_ONCOGENICITY.INCONCLUSIVE,
+                            FIREBASE_ONCOGENICITY.RESISTANCE,
+                          ].map(label => ({
+                            label,
+                            fieldKey: `mutations/${mutationIndex}/mutation_effect/oncogenic`,
+                          }))}
+                        />
                         <RealtimeCheckedInputGroup
                           groupHeader="Mutation Effect"
                           isRadio
@@ -179,22 +193,6 @@ const CurationPage = (props: ICurationPageProps) => {
                           inputClass={styles.textarea}
                           label="Description of Evidence"
                           name="description"
-                        />
-                      </Collapsible>
-                      <Collapsible nestLevel={NestLevelType.SOMATIC} className={'mt-2'} title={'Somatic'}>
-                        <RealtimeCheckedInputGroup
-                          groupHeader="Oncogenic"
-                          isRadio
-                          options={[
-                            FIREBASE_ONCOGENICITY.YES,
-                            FIREBASE_ONCOGENICITY.LIKELY,
-                            FIREBASE_ONCOGENICITY.LIKELY_NEUTRAL,
-                            FIREBASE_ONCOGENICITY.INCONCLUSIVE,
-                            FIREBASE_ONCOGENICITY.RESISTANCE,
-                          ].map(label => ({
-                            label,
-                            fieldKey: `mutations/${mutationIndex}/mutation_effect/oncogenic`,
-                          }))}
                         />
                       </Collapsible>
                       {mutation.mutation_effect.germline && (

--- a/src/main/webapp/app/pages/curation/CurationPage.tsx
+++ b/src/main/webapp/app/pages/curation/CurationPage.tsx
@@ -20,7 +20,7 @@ import ExternalLinkIcon from 'app/shared/icons/ExternalLinkIcon';
 import WithSeparator from 'react-with-separator';
 import { AutoParseRefField } from 'app/shared/form/AutoParseRefField';
 import { RealtimeCheckedInputGroup, RealtimeTextAreaInput } from 'app/shared/firebase/input/FirebaseRealtimeInput';
-import { getFirebasePath, getMutationName, getTxName } from 'app/shared/util/firebase/firebase-utils';
+import { getFirebasePath, getMutationName, getTxName, isSectionRemovableWithoutReview } from 'app/shared/util/firebase/firebase-utils';
 import Collapsible, { NestLevelType } from 'app/pages/curation/collapsible/Collapsible';
 import styles from './styles.module.scss';
 import { notifyError } from 'app/oncokb-commons/components/util/NotificationUtils';
@@ -152,10 +152,7 @@ const CurationPage = (props: ICurationPageProps) => {
                     className={'mb-1'}
                     title={`Mutation: ${getMutationName(mutation)}`}
                     mutationUuid={mutation.name_uuid}
-                    deleteHandler={() =>
-                      props.deleteGeneSection(NestLevelType.MUTATION, getFirebasePath('MUTATIONS', hugoSymbol, mutationIndex))
-                    }
-                    isRemoveableWithoutReview={props.isRemoveableWithoutReview(NestLevelType.MUTATION, `mutations/${mutationIndex}`)}
+                    firebasePath={getFirebasePath('MUTATIONS', hugoSymbol, mutationIndex)}
                   >
                     <Collapsible nestLevel={NestLevelType.MUTATION_EFFECT} title={'Mutation Effect'}>
                       <Collapsible nestLevel={NestLevelType.BIOLOGICAL_EFFECT} title={'Biological Effect'}>
@@ -249,12 +246,7 @@ const CurationPage = (props: ICurationPageProps) => {
                           cancerTypeUuid={tumor.cancerTypes_uuid}
                           key={tumor.cancerTypes_uuid}
                           nestLevel={NestLevelType.CANCER_TYPE}
-                          deleteHandler={() =>
-                            props.deleteGeneSection(
-                              NestLevelType.CANCER_TYPE,
-                              getFirebasePath('TUMORS', hugoSymbol, mutationIndex, tumorIndex)
-                            )
-                          }
+                          firebasePath={getFirebasePath('TUMORS', hugoSymbol, mutationIndex, tumorIndex)}
                           title={`Cancer Type: ${tumor.cancerTypes.map(cancerType => getCancerTypeName(cancerType)).join(', ')}`}
                         >
                           <RealtimeTextAreaInput
@@ -275,12 +267,14 @@ const CurationPage = (props: ICurationPageProps) => {
                                     key={tumor.cancerTypes_uuid}
                                     nestLevel={NestLevelType.THERAPY}
                                     title={`Therapy: ${getTxName(props.drugList, treatment.name)}`}
-                                    deleteHandler={() =>
-                                      props.deleteGeneSection(
-                                        NestLevelType.THERAPY,
-                                        getFirebasePath('TREATMENTS', hugoSymbol, mutationIndex, tumorIndex, tiIndex, treatmentIndex)
-                                      )
-                                    }
+                                    firebasePath={getFirebasePath(
+                                      'TREATMENTS',
+                                      hugoSymbol,
+                                      mutationIndex,
+                                      tumorIndex,
+                                      tiIndex,
+                                      treatmentIndex
+                                    )}
                                   >
                                     <RealtimeDropdownInput
                                       fieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/TIs/${tiIndex}/treatments/${treatmentIndex}/level`}
@@ -342,8 +336,7 @@ const mapStoreToProps = ({ geneStore, firebaseGeneStore, firebaseMetaStore, fire
   data: firebaseGeneStore.data,
   update: firebaseGeneStore.update,
   updateReviewableContent: firebaseGeneStore.updateReviewableContent,
-  deleteGeneSection: firebaseGeneStore.deleteGeneSection,
-  isRemoveableWithoutReview: firebaseGeneStore.isSectionRemoveableWithoutReview,
+  deleteSection: firebaseGeneStore.deleteSection,
   addMetaCollaboratorsListener: firebaseMetaStore.addMetaCollaboratorsListener,
   metaData: firebaseMetaStore.data,
   drugList: firebaseDrugsStore.drugList,

--- a/src/main/webapp/app/pages/curation/CurationPage.tsx
+++ b/src/main/webapp/app/pages/curation/CurationPage.tsx
@@ -28,9 +28,6 @@ import { FIREBASE_ONCOGENICITY, TX_LEVELS } from 'app/shared/model/firebase/fire
 import RealtimeDropdownInput from 'app/shared/firebase/input/RealtimeDropdownInput';
 import { GENE_TYPE, GENE_TYPE_KEY } from 'app/config/constants/firebase';
 import VusTable from '../../shared/table/VusTable';
-import DefaultTooltip from 'app/shared/tooltip/DefaultTooltip';
-import classNames from 'classnames';
-import { FaAccessibleIcon } from 'react-icons/fa';
 
 export interface ICurationPageProps extends StoreProps, RouteComponentProps<{ hugoSymbol: string }> {}
 
@@ -155,6 +152,10 @@ const CurationPage = (props: ICurationPageProps) => {
                     className={'mb-1'}
                     title={`Mutation: ${getMutationName(mutation)}`}
                     mutationUuid={mutation.name_uuid}
+                    deleteHandler={() =>
+                      props.deleteGeneSection(NestLevelType.MUTATION, getFirebasePath('MUTATIONS', hugoSymbol, mutationIndex))
+                    }
+                    isRemoveableWithoutReview={props.isRemoveableWithoutReview(NestLevelType.MUTATION, `mutations/${mutationIndex}`)}
                   >
                     <Collapsible nestLevel={NestLevelType.MUTATION_EFFECT} title={'Mutation Effect'}>
                       <Collapsible nestLevel={NestLevelType.BIOLOGICAL_EFFECT} title={'Biological Effect'}>
@@ -248,6 +249,12 @@ const CurationPage = (props: ICurationPageProps) => {
                           cancerTypeUuid={tumor.cancerTypes_uuid}
                           key={tumor.cancerTypes_uuid}
                           nestLevel={NestLevelType.CANCER_TYPE}
+                          deleteHandler={() =>
+                            props.deleteGeneSection(
+                              NestLevelType.CANCER_TYPE,
+                              getFirebasePath('TUMORS', hugoSymbol, mutationIndex, tumorIndex)
+                            )
+                          }
                           title={`Cancer Type: ${tumor.cancerTypes.map(cancerType => getCancerTypeName(cancerType)).join(', ')}`}
                         >
                           <RealtimeTextAreaInput
@@ -268,6 +275,12 @@ const CurationPage = (props: ICurationPageProps) => {
                                     key={tumor.cancerTypes_uuid}
                                     nestLevel={NestLevelType.THERAPY}
                                     title={`Therapy: ${getTxName(props.drugList, treatment.name)}`}
+                                    deleteHandler={() =>
+                                      props.deleteGeneSection(
+                                        NestLevelType.THERAPY,
+                                        getFirebasePath('TREATMENTS', hugoSymbol, mutationIndex, tumorIndex, tiIndex, treatmentIndex)
+                                      )
+                                    }
                                   >
                                     <RealtimeDropdownInput
                                       fieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/TIs/${tiIndex}/treatments/${treatmentIndex}/level`}
@@ -329,6 +342,8 @@ const mapStoreToProps = ({ geneStore, firebaseGeneStore, firebaseMetaStore, fire
   data: firebaseGeneStore.data,
   update: firebaseGeneStore.update,
   updateReviewableContent: firebaseGeneStore.updateReviewableContent,
+  deleteGeneSection: firebaseGeneStore.deleteGeneSection,
+  isRemoveableWithoutReview: firebaseGeneStore.isSectionRemoveableWithoutReview,
   addMetaCollaboratorsListener: firebaseMetaStore.addMetaCollaboratorsListener,
   metaData: firebaseMetaStore.data,
   drugList: firebaseDrugsStore.drugList,

--- a/src/main/webapp/app/pages/curation/button/DeleteSectionButton.tsx
+++ b/src/main/webapp/app/pages/curation/button/DeleteSectionButton.tsx
@@ -1,0 +1,44 @@
+import { SimpleConfirmModal } from 'app/shared/modal/SimpleConfirmModal';
+import React, { useState } from 'react';
+import { FaRegTrashAlt } from 'react-icons/fa';
+
+export interface DeleteSectionButtonProps {
+  sectionName: string;
+  deleteHandler: () => void;
+  isRemoveableWithoutReview: boolean;
+}
+
+export const DeleteSectionButton = (props: DeleteSectionButtonProps) => {
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <>
+      <span className="text-danger" style={{ cursor: 'pointer' }} onClick={() => setShowModal(true)}>
+        <FaRegTrashAlt size={16} />
+      </span>
+      <SimpleConfirmModal
+        title={'Are you sure you want to delete this section?'}
+        body={
+          <>
+            <div>
+              You are deleting the section <b>{props.sectionName}</b> and all underlying section(s).
+            </div>
+            {props.isRemoveableWithoutReview ? (
+              <div className="mt-2 text-danger">
+                This section will be removed immediately since it is newly added and has not been reviewed yet.
+              </div>
+            ) : (
+              <div className="mt-2 text-warning">This deletion will need to be reviewed before it is fully removed from our system.</div>
+            )}
+          </>
+        }
+        onCancel={() => setShowModal(false)}
+        onConfirm={() => {
+          props.deleteHandler();
+          setShowModal(false);
+        }}
+        show={showModal}
+      />
+    </>
+  );
+};

--- a/src/main/webapp/app/pages/curation/button/DeleteSectionButton.tsx
+++ b/src/main/webapp/app/pages/curation/button/DeleteSectionButton.tsx
@@ -5,7 +5,7 @@ import { FaRegTrashAlt } from 'react-icons/fa';
 export interface DeleteSectionButtonProps {
   sectionName: string;
   deleteHandler: () => void;
-  isRemoveableWithoutReview: boolean;
+  isRemovableWithoutReview: boolean;
 }
 
 export const DeleteSectionButton = (props: DeleteSectionButtonProps) => {
@@ -13,7 +13,7 @@ export const DeleteSectionButton = (props: DeleteSectionButtonProps) => {
 
   return (
     <>
-      <span className="text-danger" style={{ cursor: 'pointer' }} onClick={() => setShowModal(true)}>
+      <span style={{ cursor: 'pointer' }} onClick={() => setShowModal(true)}>
         <FaRegTrashAlt size={16} />
       </span>
       <SimpleConfirmModal
@@ -23,12 +23,10 @@ export const DeleteSectionButton = (props: DeleteSectionButtonProps) => {
             <div>
               You are deleting the section <b>{props.sectionName}</b> and all underlying section(s).
             </div>
-            {props.isRemoveableWithoutReview ? (
-              <div className="mt-2 text-danger">
-                This section will be removed immediately since it is newly added and has not been reviewed yet.
-              </div>
+            {props.isRemovableWithoutReview ? (
+              <div className="mt-2">This section will be removed immediately since it is newly added and has not been reviewed yet.</div>
             ) : (
-              <div className="mt-2 text-warning">This deletion will need to be reviewed before it is fully removed from our system.</div>
+              <div className="mt-2">This deletion will need to be reviewed before it is fully removed from our system.</div>
             )}
           </>
         }

--- a/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
@@ -28,7 +28,6 @@ export enum NestLevelType {
   SOMATIC,
   GERMLINE,
   CANCER_TYPE,
-  BIOLOGICAL_EFFECT,
   THERAPY,
 }
 
@@ -38,7 +37,6 @@ export const NestLevelMapping: { [key in NestLevelType]: string } = {
   [NestLevelType.SOMATIC]: '3',
   [NestLevelType.GERMLINE]: '3',
   [NestLevelType.CANCER_TYPE]: '2',
-  [NestLevelType.BIOLOGICAL_EFFECT]: '3',
   [NestLevelType.THERAPY]: '3',
 };
 

--- a/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
@@ -6,15 +6,17 @@ import { LEVELS } from 'app/config/colors';
 import styles from './styles.module.scss';
 import MutationLevelSummary from '../nestLevelSummary/MutationLevelSummary';
 import CancerTypeLevelSummary from '../nestLevelSummary/CancerTypeLevelSummary';
-import NestLevelSummary from '../nestLevelSummary/NestLevelSummary';
+import { DeleteSectionButton } from '../button/DeleteSectionButton';
 
-interface IProps {
+export interface IProps {
   title: string;
-  mutationUuid?: string;
-  cancerTypeUuid?: string;
   nestLevel: NestLevelType;
+  deleteHandler?: () => void;
   open?: boolean;
   className?: string;
+  isRemoveableWithoutReview?: boolean;
+  mutationUuid?: string;
+  cancerTypeUuid?: string;
 }
 
 export enum NestLevelType {
@@ -49,7 +51,19 @@ const NestLevelColor: { [key in NestLevel]: string } = {
   [NestLevel.LEVEL_3]: LEVELS['3'],
 };
 
-const Collapsible: React.FunctionComponent<IProps> = ({ open, children, title, className, nestLevel, mutationUuid, cancerTypeUuid }) => {
+export type RemoveableNestLevel = NestLevelType.MUTATION | NestLevelType.CANCER_TYPE | NestLevelType.THERAPY;
+
+const Collapsible: React.FunctionComponent<IProps> = ({
+  open,
+  children,
+  title,
+  className,
+  nestLevel,
+  deleteHandler,
+  isRemoveableWithoutReview,
+  mutationUuid,
+  cancerTypeUuid,
+}) => {
   const [isOpen, setIsOpen] = useState(open);
 
   const handleFilterOpening = () => {
@@ -57,12 +71,13 @@ const Collapsible: React.FunctionComponent<IProps> = ({ open, children, title, c
   };
 
   const showMutationLevelSummary = nestLevel === NestLevelType.MUTATION && !title.includes(',');
+  const removeableLevel = [NestLevelType.MUTATION, NestLevelType.CANCER_TYPE, NestLevelType.THERAPY].includes(nestLevel);
 
   return (
     <>
       <div className={classnames('card', className, styles.main)}>
         <div
-          className={classnames('card-header d-flex align-items-center border border-light p-1 bg-transparent', styles.header)}
+          className={classnames('card-header d-flex align-items-center p-1 bg-transparent pr-2', styles.header)}
           ref={node => {
             if (node) {
               node.style.setProperty('border-left-color', NestLevelColor[NestLevelMapping[nestLevel]], 'important');
@@ -72,10 +87,13 @@ const Collapsible: React.FunctionComponent<IProps> = ({ open, children, title, c
           <button type="button" className="btn" onClick={handleFilterOpening}>
             {isOpen ? <FontAwesomeIcon icon={faChevronDown} size={'sm'} /> : <FontAwesomeIcon icon={faChevronRight} size={'sm'} />}
           </button>
-          <span className="font-weight-bold font-weight-bold">{title}</span>
+          <span className="font-weight-bold font-weight-bold mr-auto">{title}</span>
           {showMutationLevelSummary ? <MutationLevelSummary mutationUuid={mutationUuid} /> : undefined}
           {nestLevel === NestLevelType.CANCER_TYPE ? (
             <CancerTypeLevelSummary mutationUuid={mutationUuid} cancerTypeUuid={cancerTypeUuid} />
+          ) : undefined}
+          {removeableLevel ? (
+            <DeleteSectionButton sectionName={title} deleteHandler={deleteHandler} isRemoveableWithoutReview={isRemoveableWithoutReview} />
           ) : undefined}
         </div>
         {isOpen && <div className={classnames('card-body', styles.body)}>{children}</div>}

--- a/src/main/webapp/app/pages/curation/collapsible/styles.module.scss
+++ b/src/main/webapp/app/pages/curation/collapsible/styles.module.scss
@@ -8,7 +8,7 @@
 }
 
 .body {
-  padding-top: 0.5rem;
-  padding-bottom: 0;
-  padding-right: 0;
+  padding-top: 0.5rem !important;
+  padding-bottom: 0 !important;
+  padding-right: 0 !important;
 }

--- a/src/main/webapp/app/pages/curation/collapsible/styles.module.scss
+++ b/src/main/webapp/app/pages/curation/collapsible/styles.module.scss
@@ -12,3 +12,12 @@
   padding-bottom: 0 !important;
   padding-right: 0 !important;
 }
+
+.divider {
+  height: 1rem;
+  background: $grey;
+  width: 1px;
+  margin-right: 0.75rem;
+  margin-top: 0.5rem;
+  border-radius: 5px;
+}

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
@@ -22,56 +22,80 @@ export interface NestLevelSummaryProps {
 }
 
 export const NestLevelSummary = (props: NestLevelSummaryProps) => {
-  const wrapperMarginRight = props.summaryStats.oncogenicity ? undefined : 'mr-2';
+  const summaryKeys: (keyof NestLevelSummaryStats)[] = ['TTS', 'DxS', 'PxS'];
+
+  let lastBadgeHasHiddenNumber = false;
+
+  const badges = (
+    <>
+      {Object.keys(props.summaryStats)
+        .filter(k => props.summaryStats[k] && props.summaryStats[k] > 0)
+        .map(k => {
+          const hideWhenOne = summaryKeys.includes(k as keyof NestLevelSummaryStats);
+          if (hideWhenOne) {
+            lastBadgeHasHiddenNumber = true;
+          }
+          return (
+            <CountBadge
+              count={props.summaryStats[k]}
+              base={k}
+              key={`summaries-${k}`}
+              hideWhenOne={summaryKeys.includes(k as keyof NestLevelSummaryStats)}
+            />
+          );
+        })}
+      {Object.keys(props.summaryStats.txLevels).map(k => {
+        lastBadgeHasHiddenNumber = false;
+        return (
+          <CountBadge
+            count={props.summaryStats.txLevels[k]}
+            base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
+            key={`tx-levels-${k}`}
+          />
+        );
+      })}
+      {Object.keys(props.summaryStats.dxLevels).map(k => {
+        lastBadgeHasHiddenNumber = false;
+        return (
+          <CountBadge
+            count={props.summaryStats.dxLevels[k]}
+            base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
+            key={`dx-levels-${k}`}
+          />
+        );
+      })}
+      {Object.keys(props.summaryStats.pxLevels).map(k => {
+        lastBadgeHasHiddenNumber = false;
+        return (
+          <CountBadge
+            count={props.summaryStats.pxLevels[k]}
+            base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
+            key={`px-levels-${k}`}
+          />
+        );
+      })}
+      {props.summaryStats.oncogenicity ? (
+        <CountBadge
+          hideWhenOne
+          count={1}
+          base={
+            <DefaultTooltip placement="top" overlay={<span>{FIREBASE_ONCOGENICITY_MAPPING[props.summaryStats.oncogenicity]}</span>}>
+              <span className={classNames('oncokb', 'icon', `${ONCOGENICITY_CLASS_MAPPING[props.summaryStats.oncogenicity]}`)}></span>
+            </DefaultTooltip>
+          }
+        />
+      ) : undefined}
+    </>
+  );
+
+  if (props.summaryStats.oncogenicity) {
+    lastBadgeHasHiddenNumber = true;
+  }
+
+  const wrapperMarginRight = lastBadgeHasHiddenNumber ? undefined : 'mr-2';
 
   if (props.summaryStats) {
-    return (
-      <div className={classNames('d-flex align-items-center flex-wrap', wrapperMarginRight)}>
-        {Object.keys(props.summaryStats)
-          .filter(k => props.summaryStats[k] && props.summaryStats[k] > 0)
-          .map(k => {
-            return <CountBadge count={props.summaryStats[k]} base={k} key={`summaries-${k}`} />;
-          })}
-        {Object.keys(props.summaryStats.txLevels).map(k => {
-          return (
-            <CountBadge
-              count={props.summaryStats.txLevels[k]}
-              base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
-              key={`tx-levels-${k}`}
-            />
-          );
-        })}
-        {Object.keys(props.summaryStats.dxLevels).map(k => {
-          return (
-            <CountBadge
-              count={props.summaryStats.dxLevels[k]}
-              base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
-              key={`dx-levels-${k}`}
-            />
-          );
-        })}
-        {Object.keys(props.summaryStats.pxLevels).map(k => {
-          return (
-            <CountBadge
-              count={props.summaryStats.pxLevels[k]}
-              base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
-              key={`px-levels-${k}`}
-            />
-          );
-        })}
-        {props.summaryStats.oncogenicity ? (
-          <CountBadge
-            hideWhenOne
-            count={1}
-            base={
-              <DefaultTooltip placement="top" overlay={<span>{FIREBASE_ONCOGENICITY_MAPPING[props.summaryStats.oncogenicity]}</span>}>
-                <span className={classNames('oncokb', 'icon', `${ONCOGENICITY_CLASS_MAPPING[props.summaryStats.oncogenicity]}`)}></span>
-              </DefaultTooltip>
-            }
-          />
-        ) : undefined}
-      </div>
-    );
+    return <div className={classNames('d-flex align-items-center', wrapperMarginRight)}>{badges}</div>;
   }
   return <div></div>;
 };

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
@@ -3,6 +3,7 @@ import CountBadge from 'app/shared/badge/CountBadge';
 import DefaultTooltip from 'app/shared/tooltip/DefaultTooltip';
 import classNames from 'classnames';
 import _ from 'lodash';
+import './nest-level-summary.scss';
 import React from 'react';
 
 export type NestLevelSummaryStats = {
@@ -21,9 +22,11 @@ export interface NestLevelSummaryProps {
 }
 
 export const NestLevelSummary = (props: NestLevelSummaryProps) => {
+  const wrapperMarginRight = props.summaryStats.oncogenicity ? undefined : 'mr-2';
+
   if (props.summaryStats) {
     return (
-      <div className="d-flex flex-wrap">
+      <div className={classNames('d-flex align-items-center flex-wrap', wrapperMarginRight)}>
         {Object.keys(props.summaryStats)
           .filter(k => props.summaryStats[k] && props.summaryStats[k] > 0)
           .map(k => {

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
@@ -23,7 +23,7 @@ export interface NestLevelSummaryProps {
 export const NestLevelSummary = (props: NestLevelSummaryProps) => {
   if (props.summaryStats) {
     return (
-      <div className="ml-auto d-flex flex-wrap">
+      <div className="d-flex flex-wrap">
         {Object.keys(props.summaryStats)
           .filter(k => props.summaryStats[k] && props.summaryStats[k] > 0)
           .map(k => {

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/nest-level-summary.scss
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/nest-level-summary.scss
@@ -1,0 +1,4 @@
+// Override oncokb-styles icon
+.oncokb.icon {
+  margin: 0 !important;
+}

--- a/src/main/webapp/app/shared/badge/count-badge.scss
+++ b/src/main/webapp/app/shared/badge/count-badge.scss
@@ -1,7 +1,3 @@
-.oncokb.icon {
-  margin: 0;
-}
-
 .count-badge-wrapper {
   font-size: 90%;
   position: relative;

--- a/src/main/webapp/app/shared/firebase/input/RealtimeBasicInput.tsx
+++ b/src/main/webapp/app/shared/firebase/input/RealtimeBasicInput.tsx
@@ -72,7 +72,7 @@ const RealtimeBasicInput: React.FunctionComponent<IRealtimeBasicInput> = (props:
     <Input
       className={classNames(inputClass, isCheckType && 'ml-1 position-relative')}
       id={id}
-      name={label.toLowerCase()}
+      name={`${id}-${label.toLowerCase()}`}
       autoComplete="off"
       onChange={e => {
         inputChangeHandler(e);

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -192,6 +192,7 @@ export class Tumor {
   // We should remove this in future
   TIs: TI[] = [new TI(TI_TYPE.SS), new TI(TI_TYPE.SR), new TI(TI_TYPE.IS), new TI(TI_TYPE.IR)];
   cancerTypes: CancerType[] = [];
+  cancerTypes_review?: Review;
   cancerTypes_uuid: string = generateUuid();
   diagnostic: Implication = new Implication();
   diagnosticSummary = '';

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -156,6 +156,10 @@ export class Mutation {
   name_uuid: string = generateUuid();
   tumors: Tumor[] = [];
   tumors_uuid: string = generateUuid();
+
+  constructor(name: string) {
+    this.name = name;
+  }
 }
 
 export class MutationEffect {
@@ -316,9 +320,18 @@ export class Review {
   added?: boolean;
   removed?: boolean;
 
-  constructor(updatedBy: string) {
+  constructor(updatedBy: string, lastReviewed?: string, added?: boolean, removed?: boolean) {
     this.updatedBy = updatedBy;
     this.updateTime = new Date().getTime();
+    if (lastReviewed) {
+      this.lastReviewed = lastReviewed;
+    }
+    if (added) {
+      this.added = added;
+    }
+    if (removed) {
+      this.removed = removed;
+    }
   }
 }
 

--- a/src/main/webapp/app/shared/table/OncoKBAsyncTable.tsx
+++ b/src/main/webapp/app/shared/table/OncoKBAsyncTable.tsx
@@ -20,7 +20,6 @@ export type PaginationState<T> = {
   activePage: number;
 };
 
-/* eslint-disable no-console */
 export const OncoKBAsyncTable = <T extends object>(props: IOncoKBAsyncTableProps<T>) => {
   const [searchKeyword, setSearchKeyword] = useState('');
   const [pageSize, setPageSize] = useState(props.defaultPageSize || ITEMS_PER_PAGE);

--- a/src/main/webapp/app/shared/table/VusTable.tsx
+++ b/src/main/webapp/app/shared/table/VusTable.tsx
@@ -30,7 +30,6 @@ const LAST_EDITED_BY = 'Last Edited By';
 const LAST_EDITED_AT = 'Last Edited At';
 const LATEST_COMMENT = 'Latest Comment';
 
-/* eslint-disable no-console */
 const VusTable = ({
   hugoSymbol,
   account,

--- a/src/main/webapp/app/shared/util/firebase/firebase-path-utils.spec.ts
+++ b/src/main/webapp/app/shared/util/firebase/firebase-path-utils.spec.ts
@@ -1,0 +1,24 @@
+import { FB_COLLECTION } from 'app/config/constants/firebase';
+import { parseFirebaseGenePath } from './firebase-path-utils';
+
+describe('Firebase path utils test', () => {
+  describe('Parse firebase gene path', () => {
+    it('Should parse path', () => {
+      const path = `${FB_COLLECTION.GENES}/BRAF/mutations/0`;
+      const pathDetails = parseFirebaseGenePath(path);
+      expect(pathDetails.fullPath).toEqual(path);
+      expect(pathDetails.hugoSymbol).toEqual('BRAF');
+      expect(pathDetails.pathFromGene).toEqual('mutations/0');
+    });
+    it('Should not parse path with less than 3 parts', () => {
+      let path = `${FB_COLLECTION.GENES}`;
+      expect(parseFirebaseGenePath(path)).toBeUndefined();
+
+      path = `${FB_COLLECTION.GENES}/BRAF`;
+      expect(parseFirebaseGenePath(path)).toBeUndefined();
+
+      path = `${FB_COLLECTION.GENES}/BRAF/`;
+      expect(parseFirebaseGenePath(path)).toBeUndefined();
+    });
+  });
+});

--- a/src/main/webapp/app/shared/util/firebase/firebase-path-utils.ts
+++ b/src/main/webapp/app/shared/util/firebase/firebase-path-utils.ts
@@ -1,0 +1,19 @@
+type FirebaseGenePathDetails = {
+  fullPath: string;
+  hugoSymbol: string;
+  pathFromGene: string;
+};
+
+export const parseFirebaseGenePath = (path: string) => {
+  const pathParts = path.split('/').filter(part => part.length > 0);
+  if (pathParts.length < 3) {
+    return;
+  }
+  const pathFromGene = pathParts.slice(2).join('/');
+  const hugoSymbol = pathParts[1];
+  return {
+    fullPath: path,
+    hugoSymbol,
+    pathFromGene,
+  } as FirebaseGenePathDetails;
+};

--- a/src/main/webapp/app/shared/util/firebase/firebase-utils.ts
+++ b/src/main/webapp/app/shared/util/firebase/firebase-utils.ts
@@ -1,7 +1,9 @@
 import { UUID_REGEX } from 'app/config/constants/constants';
-import { Comment, DrugCollection, Meta, Mutation } from 'app/shared/model/firebase/firebase.model';
+import { Comment, DrugCollection, Gene, Meta, Mutation, Review } from 'app/shared/model/firebase/firebase.model';
 import { replaceUrlParams } from '../url-utils';
 import { FB_COLLECTION_PATH } from 'app/config/constants/firebase';
+import { NestLevelType, RemovableNestLevel } from 'app/pages/curation/collapsible/Collapsible';
+import { parseFirebaseGenePath } from './firebase-path-utils';
 
 /* Convert a nested object into an object where the key is the path to the object.
   Example:
@@ -88,3 +90,17 @@ export function getMostRecentComment(comments: Comment[]) {
   }
   return latestComment;
 }
+
+export const isSectionRemovableWithoutReview = (geneData: Gene, nestLevel: RemovableNestLevel, fullPath: string) => {
+  let reviewKey;
+  if (nestLevel === NestLevelType.MUTATION || nestLevel === NestLevelType.THERAPY) {
+    reviewKey = 'name_review';
+  } else {
+    reviewKey = 'cancerTypes_review';
+  }
+
+  const pathDetails = parseFirebaseGenePath(fullPath);
+
+  const review: Review = getValueByNestedKey(geneData, `${pathDetails.pathFromGene}/${reviewKey}`);
+  return !!review && !!review.added;
+};

--- a/src/main/webapp/app/shared/util/firebase/firebase-utils.ts
+++ b/src/main/webapp/app/shared/util/firebase/firebase-utils.ts
@@ -75,7 +75,7 @@ export const geneNeedsReview = (meta: Meta | undefined) => {
   return needsReview;
 };
 
-export const getFirebasePath = (type: keyof typeof FB_COLLECTION_PATH, ...params: string[]) => {
+export const getFirebasePath = (type: keyof typeof FB_COLLECTION_PATH, ...params: (string | number)[]) => {
   return replaceUrlParams(FB_COLLECTION_PATH[type], ...params);
 };
 
@@ -88,3 +88,9 @@ export function getMostRecentComment(comments: Comment[]) {
   }
   return latestComment;
 }
+
+export const deleteFromArrayByIndex = (array: any[], index: number) => {
+  return array.filter((e, i) => {
+    return i !== index;
+  });
+};

--- a/src/main/webapp/app/shared/util/firebase/firebase-utils.ts
+++ b/src/main/webapp/app/shared/util/firebase/firebase-utils.ts
@@ -88,9 +88,3 @@ export function getMostRecentComment(comments: Comment[]) {
   }
   return latestComment;
 }
-
-export const deleteFromArrayByIndex = (array: any[], index: number) => {
-  return array.filter((e, i) => {
-    return i !== index;
-  });
-};

--- a/src/main/webapp/app/shared/util/url-utils.spec.ts
+++ b/src/main/webapp/app/shared/util/url-utils.spec.ts
@@ -25,6 +25,9 @@ describe('UrlUtils', () => {
       expect(replaceUrlParams('/:hugoSymbol', '')).toBe('');
       expect(replaceUrlParams('/:hugoSymbol/mutations/:index', '', undefined)).toBe('');
       expect(replaceUrlParams('/:hugoSymbol', undefined)).toBe('');
+
+      expect(replaceUrlParams('/:index', 0)).toBe('/0');
+      expect(replaceUrlParams('/:index', '0')).toBe('/0');
     });
   });
 });

--- a/src/main/webapp/app/shared/util/url-utils.ts
+++ b/src/main/webapp/app/shared/util/url-utils.ts
@@ -1,4 +1,4 @@
-export const replaceUrlParams = (url: string, ...params: string[]) => {
+export const replaceUrlParams = (url: string, ...params: (string | number)[]) => {
   if (!url) {
     return '';
   }
@@ -15,7 +15,7 @@ export const replaceUrlParams = (url: string, ...params: string[]) => {
   }
 
   for (let i = 0; i < paramMatches.length; i++) {
-    if (!params[i]) {
+    if (params[i] === undefined) {
       return '';
     }
     url = url.replace(paramMatches[i], `/${params[i]}`);

--- a/src/main/webapp/app/shared/util/url-utils.ts
+++ b/src/main/webapp/app/shared/util/url-utils.ts
@@ -15,7 +15,7 @@ export const replaceUrlParams = (url: string, ...params: (string | number)[]) =>
   }
 
   for (let i = 0; i < paramMatches.length; i++) {
-    if (params[i] === undefined) {
+    if (params[i] === undefined || params[i] === '') {
       return '';
     }
     url = url.replace(paramMatches[i], `/${params[i]}`);

--- a/src/main/webapp/app/stores/firebase/firebase.gene.store.spec.ts
+++ b/src/main/webapp/app/stores/firebase/firebase.gene.store.spec.ts
@@ -1,0 +1,138 @@
+const mockUpdate = jest.fn().mockImplementation((db, value) => Promise.resolve());
+const mockRemove = jest.fn().mockImplementation((db, value) => {});
+const mockRef = jest.fn().mockImplementation(db => {});
+const mockRunTransaction = jest.fn().mockImplementation((db, transactionUpdate) => {});
+const mockUuidReturnValue = 'fake-uuid';
+
+import 'jest-expect-message';
+import { FirebaseGeneStore } from './firebase.gene.store';
+import { NestLevelType } from 'app/pages/curation/collapsible/Collapsible';
+import { getFirebasePath } from 'app/shared/util/firebase/firebase-utils';
+import { CancerType, Gene, Mutation, Review, Treatment, Tumor } from 'app/shared/model/firebase/firebase.model';
+import { FirebaseMetaStore } from './firebase.meta.store';
+import { FirebaseCrudStore } from 'app/shared/util/firebase/firebase-crud-store';
+import FirebaseStore from './firebase.store';
+
+jest.mock('uuid', () => ({ v4: jest.fn().mockReturnValue(mockUuidReturnValue) }));
+
+jest.mock('firebase/database', () => {
+  return {
+    ref: mockRef,
+    update: mockUpdate,
+    remove: mockRemove,
+    runTransaction: mockRunTransaction,
+  };
+});
+
+const deleteFromArrayMock = jest.spyOn(FirebaseCrudStore.prototype, 'deleteFromArray').mockReturnValue(Promise.resolve(undefined));
+const updateGeneMetaContentMock = jest.spyOn(FirebaseMetaStore.prototype, 'updateGeneMetaContent').mockReturnValue(Promise.resolve());
+const updateGeneReviewUuidMock = jest.spyOn(FirebaseMetaStore.prototype, 'updateGeneReviewUuid').mockReturnValue(Promise.resolve());
+
+describe('FirebaseGeneStore', () => {
+  // Variables used in tests
+  let rootStore = undefined;
+  const DEFAULT_USER = 'test user';
+  const DEFAULT_DATE = new Date('2023-09-21');
+
+  class TestRootStore {
+    firebaseStore;
+    firebaseMetaStore;
+    authStore;
+    constructor() {
+      this.firebaseStore = new FirebaseStore(this as any);
+      this.firebaseMetaStore = new FirebaseMetaStore(this as any);
+      this.authStore = { fullName: DEFAULT_USER };
+    }
+  }
+
+  const reset = () => {
+    jest.useFakeTimers().setSystemTime(DEFAULT_DATE);
+    rootStore = new TestRootStore();
+    jest.clearAllMocks();
+  };
+
+  describe('deleteSection', () => {
+    beforeEach(() => reset());
+
+    it('should delete immediately when content has been added', async () => {
+      const store = new FirebaseGeneStore(rootStore);
+      const gene = new Gene('BRAF');
+      const mutation = new Mutation('V600E');
+      mutation.name_review = new Review(DEFAULT_USER, undefined, true);
+      gene.mutations.push(mutation);
+      store.data = gene;
+      await store.deleteSection(NestLevelType.MUTATION, getFirebasePath('MUTATIONS', 'BRAF', '0'));
+
+      expect(deleteFromArrayMock).toHaveBeenNthCalledWith(1, 'Genes/BRAF/mutations', [0]);
+
+      expect(updateGeneMetaContentMock).toHaveBeenCalledTimes(0);
+      expect(updateGeneReviewUuidMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('should review before deleting mutation', async () => {
+      const store = new FirebaseGeneStore(rootStore);
+      const gene = new Gene('BRAF');
+      const mutation = new Mutation('V600E');
+      mutation.name_review = new Review(DEFAULT_USER);
+      gene.mutations.push(mutation);
+      store.data = gene;
+      await store.deleteSection(NestLevelType.MUTATION, getFirebasePath('MUTATIONS', 'BRAF', '0'));
+
+      expect(deleteFromArrayMock).toHaveBeenCalledTimes(0);
+
+      expect(mockUpdate).toHaveBeenNthCalledWith(1, undefined, {
+        name_review: { removed: true, updateTime: DEFAULT_DATE.getTime(), updatedBy: DEFAULT_USER },
+      });
+
+      expect(updateGeneMetaContentMock).toHaveBeenNthCalledWith(1, 'BRAF');
+      expect(updateGeneReviewUuidMock).toHaveBeenNthCalledWith(1, 'BRAF', mockUuidReturnValue, true);
+    });
+
+    it('should review before deleting cancer type', async () => {
+      const store = new FirebaseGeneStore(rootStore);
+      const gene = new Gene('BRAF');
+      const mutation = new Mutation('V600E');
+      mutation.name_review = new Review(DEFAULT_USER);
+      gene.mutations.push(mutation);
+      const tumor = new Tumor();
+      tumor.cancerTypes_review = new Review(DEFAULT_USER);
+      mutation.tumors.push(tumor);
+      store.data = gene;
+      await store.deleteSection(NestLevelType.CANCER_TYPE, getFirebasePath('TUMORS', 'BRAF', '0', '0'));
+
+      expect(deleteFromArrayMock).toHaveBeenCalledTimes(0);
+
+      expect(mockUpdate).toHaveBeenNthCalledWith(1, undefined, {
+        cancerTypes_review: { removed: true, updateTime: DEFAULT_DATE.getTime(), updatedBy: DEFAULT_USER },
+      });
+
+      expect(updateGeneMetaContentMock).toHaveBeenNthCalledWith(1, 'BRAF');
+      expect(updateGeneReviewUuidMock).toHaveBeenNthCalledWith(1, 'BRAF', mockUuidReturnValue, true);
+    });
+
+    it('should review before deleting therapy', async () => {
+      const store = new FirebaseGeneStore(rootStore);
+      const gene = new Gene('BRAF');
+      const mutation = new Mutation('V600E');
+      mutation.name_review = new Review(DEFAULT_USER);
+      gene.mutations.push(mutation);
+      const tumor = new Tumor();
+      tumor.cancerTypes_review = new Review(DEFAULT_USER);
+      mutation.tumors.push(tumor);
+      const treatment = new Treatment('Vemurafenib');
+      treatment.name_review = new Review(DEFAULT_USER);
+      tumor.TIs[0].treatments.push(treatment);
+      store.data = gene;
+      await store.deleteSection(NestLevelType.THERAPY, getFirebasePath('TREATMENTS', 'BRAF', '0', '0', '0', '0'));
+
+      expect(deleteFromArrayMock).toHaveBeenCalledTimes(0);
+
+      expect(mockUpdate).toHaveBeenNthCalledWith(1, undefined, {
+        name_review: { removed: true, updateTime: DEFAULT_DATE.getTime(), updatedBy: DEFAULT_USER },
+      });
+
+      expect(updateGeneMetaContentMock).toHaveBeenNthCalledWith(1, 'BRAF');
+      expect(updateGeneReviewUuidMock).toHaveBeenNthCalledWith(1, 'BRAF', mockUuidReturnValue, true);
+    });
+  });
+});

--- a/src/main/webapp/app/stores/firebase/firebase.gene.store.ts
+++ b/src/main/webapp/app/stores/firebase/firebase.gene.store.ts
@@ -1,9 +1,12 @@
-import { DX_LEVELS, Gene, FIREBASE_ONCOGENICITY, PX_LEVELS, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
+import { DX_LEVELS, Gene, FIREBASE_ONCOGENICITY, PX_LEVELS, TX_LEVELS, Review } from 'app/shared/model/firebase/firebase.model';
 import { IRootStore } from '../createStore';
 import { FirebaseReviewableCrudStore } from 'app/shared/util/firebase/firebase-reviewable-crud-store';
 import { ExtractPathExpressions } from 'app/shared/util/firebase/firebase-crud-store';
 import { notifyError } from 'app/oncokb-commons/components/util/NotificationUtils';
-import { computed, makeObservable } from 'mobx';
+import { action, computed, makeObservable } from 'mobx';
+import { NestLevelType, RemoveableNestLevel } from 'app/pages/curation/collapsible/Collapsible';
+import { ref, update } from '@firebase/database';
+import { getValueByNestedKey } from 'app/shared/util/firebase/firebase-utils';
 
 export type AllLevelSummary = {
   [mutationUuid: string]: {
@@ -25,6 +28,7 @@ export class FirebaseGeneStore extends FirebaseReviewableCrudStore<Gene> {
     super(rootStore);
     makeObservable(this, {
       mutationSummaryStats: computed,
+      deleteGeneSection: action.bound,
     });
   }
 
@@ -82,6 +86,84 @@ export class FirebaseGeneStore extends FirebaseReviewableCrudStore<Gene> {
       return super.updateReviewableContent(path, key, value);
     } catch (error) {
       notifyError(error, `Could not update ${key} at location ${path}`);
+    }
+  }
+
+  isSectionRemoveableWithoutReview = (nestLevel: RemoveableNestLevel, sectionToRemovePath: string) => {
+    let reviewKey;
+    if (nestLevel === NestLevelType.MUTATION || nestLevel === NestLevelType.THERAPY) {
+      reviewKey = 'name_review';
+    } else {
+      reviewKey = 'cancerTypes_review';
+    }
+    const review: Review = getValueByNestedKey(this.data, `${sectionToRemovePath}/${reviewKey}`);
+    return !!review && !!review.added;
+  };
+
+  async deleteGeneSection(nestLevel: NestLevelType, path: string) {
+    /* eslint-disable no-console */
+
+    if (![NestLevelType.MUTATION, NestLevelType.CANCER_TYPE, NestLevelType.THERAPY].includes(nestLevel)) {
+      return Promise.reject(new Error('Cannot delete an invalid section'));
+    }
+
+    const name = this.rootStore?.authStore?.fullName;
+    if (!name) {
+      return Promise.reject(new Error('Cannot update collaborator with undefined name'));
+    }
+
+    // Check if section can be removed immediately
+    const pathFromGene = path.split('/').slice(2).join('/');
+    let removeWithoutReview = false;
+    let name_review: Review | undefined = undefined;
+    let cancerTypes_review: Review | undefined = undefined;
+    let reviewKey;
+
+    if (nestLevel === NestLevelType.MUTATION || nestLevel === NestLevelType.THERAPY) {
+      reviewKey = 'name';
+      name_review = getValueByNestedKey(this.data, `${pathFromGene}/${reviewKey}_review`);
+      removeWithoutReview = !!name_review && !!name_review.added;
+      name_review = {
+        updatedBy: name,
+        updateTime: new Date().getTime(),
+        removed: true,
+      };
+    } else if (nestLevel === NestLevelType.CANCER_TYPE) {
+      reviewKey = 'cancerTypes';
+      cancerTypes_review = getValueByNestedKey(this.data, `${pathFromGene}/${reviewKey}_review`);
+      removeWithoutReview = !!cancerTypes_review && !!cancerTypes_review.added;
+      cancerTypes_review = {
+        updatedBy: name,
+        updateTime: new Date().getTime(),
+        removed: true,
+      };
+    }
+
+    const hugoSymbol = path.split('/')[1];
+    if (!hugoSymbol) {
+      return Promise.reject(new Error('Cannot update when hugoSymbol is undefined'));
+    }
+
+    if (removeWithoutReview) {
+      const pathParts = path.split('/');
+      const indexToRemove = parseInt(pathParts.pop(), 10);
+      const arrayPath = pathParts.join('/');
+      return this.deleteFromArray(arrayPath, [indexToRemove]);
+    }
+
+    const uuid = getValueByNestedKey(this.data, `${pathFromGene}/${reviewKey}_uuid`);
+
+    // Let the deletion be reviewed
+    if (nestLevel === NestLevelType.MUTATION || nestLevel === NestLevelType.THERAPY) {
+      return update(ref(this.db, path), { name_review }).then(() => {
+        this.rootStore.firebaseMetaStore.updateGeneMetaContent(hugoSymbol);
+        this.rootStore.firebaseMetaStore.updateGeneReviewUuid(hugoSymbol, uuid, true);
+      });
+    } else if (nestLevel === NestLevelType.CANCER_TYPE) {
+      return update(ref(this.db, path), { cancerTypes_review }).then(() => {
+        this.rootStore.firebaseMetaStore.updateGeneMetaContent(hugoSymbol);
+        this.rootStore.firebaseMetaStore.updateGeneReviewUuid(hugoSymbol, uuid, true);
+      });
     }
   }
 }

--- a/src/main/webapp/app/stores/firebase/firebase.gene.store.ts
+++ b/src/main/webapp/app/stores/firebase/firebase.gene.store.ts
@@ -101,8 +101,6 @@ export class FirebaseGeneStore extends FirebaseReviewableCrudStore<Gene> {
   };
 
   async deleteGeneSection(nestLevel: NestLevelType, path: string) {
-    /* eslint-disable no-console */
-
     if (![NestLevelType.MUTATION, NestLevelType.CANCER_TYPE, NestLevelType.THERAPY].includes(nestLevel)) {
       return Promise.reject(new Error('Cannot delete an invalid section'));
     }


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb/issues/3608

Todo(s):
- [x] Add tests for `isSectionRemovableWithoutReview`

### Delete icon in `Collapsible` 
![view](https://github.com/oncokb/oncokb-transcript/assets/59149377/306f3583-4ff3-469f-832e-46e400bf064f)

### Modal when item can be deleted immediately
![delete](https://github.com/oncokb/oncokb-transcript/assets/59149377/c5d89bce-ebb9-47dd-8b50-0a4a36ee7c76)


### Modal when item to be deleted needs review first
![delete_review](https://github.com/oncokb/oncokb-transcript/assets/59149377/4d1a8392-5956-42bc-8a40-00bd8647ea21)
