### PR TITLE
Minor changes to curation page

### DIFF
--- a/src/main/webapp/app/pages/curation/CurationPage.tsx
+++ b/src/main/webapp/app/pages/curation/CurationPage.tsx
@@ -25,7 +25,7 @@ import { getFirebasePath, getMutationName, getTxName } from 'app/shared/util/fir
 import Collapsible, { NestLevelType } from 'app/pages/curation/collapsible/Collapsible';
 import styles from './styles.module.scss';
 import { notifyError } from 'app/oncokb-commons/components/util/NotificationUtils';
-import { FIREBASE_ONCOGENICITY, HistoryRecord, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
+import { DX_LEVELS, FIREBASE_ONCOGENICITY, HistoryRecord, PX_LEVELS, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
 import RealtimeDropdownInput from 'app/shared/firebase/input/RealtimeDropdownInput';
 import { GENE_TYPE, GENE_TYPE_KEY } from 'app/config/constants/firebase';
 import GeneHistoryTooltip from 'app/components/geneHistoryTooltip/GeneHistoryTooltip';
@@ -217,11 +217,13 @@ const CurationPage = (props: ICurationPageProps) => {
                     >
                       <Collapsible
                         nestLevel={NestLevelType.MUTATION_EFFECT}
+                        open
                         title={'Mutation Effect'}
                         geneFieldKey={`mutations/${mutationIndex}/mutation_effect`}
                       >
                         <Collapsible
                           nestLevel={NestLevelType.SOMATIC}
+                          open
                           title={'Somatic'}
                           geneFieldKey={`mutations/${mutationIndex}/mutation_effect/oncogenic`}
                         >
@@ -291,10 +293,14 @@ const CurationPage = (props: ICurationPageProps) => {
                             }
                             name="description"
                           />
+                          <div className="mb-2">
+                            <AutoParseRefField summary={mutation.mutation_effect.description} />
+                          </div>
                         </Collapsible>
                         {mutation.mutation_effect.germline && (
                           <Collapsible
                             nestLevel={NestLevelType.GERMLINE}
+                            open
                             className={'mt-2'}
                             title={'Germline'}
                             geneFieldKey="mutations/0/mutation_effect/germline"
@@ -361,7 +367,7 @@ const CurationPage = (props: ICurationPageProps) => {
                             >
                               <RealtimeTextAreaInput
                                 fieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/summary`}
-                                inputClass={styles.textarea}
+                                inputClass={styles.summaryTextarea}
                                 label="Therapeutic Summary (Optional)"
                                 labelIcon={
                                   <GeneHistoryTooltip
@@ -371,6 +377,76 @@ const CurationPage = (props: ICurationPageProps) => {
                                 }
                                 name="txSummary"
                               />
+                              <RealtimeTextAreaInput
+                                fieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/diagnosticSummary`}
+                                inputClass={styles.summaryTextarea}
+                                label="Diagnostic Summary (Optional)"
+                                labelIcon={
+                                  <GeneHistoryTooltip
+                                    historyData={parsedHistoryList}
+                                    location={`${getMutationName(mutation)}, ${cancerTypeName}, Diagnostic Summary`}
+                                  />
+                                }
+                                name="dxSummary"
+                              />
+                              <RealtimeTextAreaInput
+                                fieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/prognosticSummary`}
+                                inputClass={styles.summaryTextarea}
+                                label="Prognostic Summary (Optional)"
+                                labelIcon={
+                                  <GeneHistoryTooltip
+                                    historyData={parsedHistoryList}
+                                    location={`${getMutationName(mutation)}, ${cancerTypeName}, Prognostic Summary`}
+                                  />
+                                }
+                                name="pxSummary"
+                              />
+                              <Collapsible
+                                className={'mt-2'}
+                                key={tumor.diagnostic_uuid}
+                                nestLevel={NestLevelType.DIAGNOSTIC}
+                                title={'Diagnostic implication'}
+                                geneFieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/diagnostic`}
+                              >
+                                <RealtimeDropdownInput
+                                  fieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/diagnostic/level`}
+                                  label="Level of evidence"
+                                  name="level"
+                                  options={[DX_LEVELS.LEVEL_DX1, DX_LEVELS.LEVEL_DX2, DX_LEVELS.LEVEL_DX3]}
+                                />
+                                <RealtimeTextAreaInput
+                                  fieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/diagnostic/description`}
+                                  inputClass={styles.textarea}
+                                  label="Description of Evidence"
+                                  name="evidenceDescription"
+                                />
+                                <div className="mb-2">
+                                  <AutoParseRefField summary={tumor.diagnostic.description} />
+                                </div>
+                              </Collapsible>
+                              <Collapsible
+                                className={'mt-2'}
+                                key={tumor.prognostic_uuid}
+                                nestLevel={NestLevelType.PROGNOSTIC}
+                                title={'Prognostic implication'}
+                                geneFieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/prognostic`}
+                              >
+                                <RealtimeDropdownInput
+                                  fieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/prognostic/level`}
+                                  label="Level of evidence"
+                                  name="level"
+                                  options={[PX_LEVELS.LEVEL_PX1, PX_LEVELS.LEVEL_PX2, PX_LEVELS.LEVEL_PX3]}
+                                />
+                                <RealtimeTextAreaInput
+                                  fieldKey={`mutations/${mutationIndex}/tumors/${tumorIndex}/prognostic/description`}
+                                  inputClass={styles.textarea}
+                                  label="Description of Evidence"
+                                  name="evidenceDescription"
+                                />
+                                <div className="mb-2">
+                                  <AutoParseRefField summary={tumor.prognostic.description} />
+                                </div>
+                              </Collapsible>
                               {tumor.TIs.reduce((accumulator, ti, tiIndex) => {
                                 if (!ti.treatments) {
                                   return accumulator;

--- a/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/Collapsible.tsx
@@ -32,6 +32,8 @@ export enum NestLevelType {
   SOMATIC,
   GERMLINE,
   CANCER_TYPE,
+  DIAGNOSTIC,
+  PROGNOSTIC,
   THERAPY,
 }
 
@@ -41,6 +43,8 @@ export const NestLevelMapping: { [key in NestLevelType]: string } = {
   [NestLevelType.SOMATIC]: '3',
   [NestLevelType.GERMLINE]: '3',
   [NestLevelType.CANCER_TYPE]: '2',
+  [NestLevelType.DIAGNOSTIC]: '3',
+  [NestLevelType.PROGNOSTIC]: '3',
   [NestLevelType.THERAPY]: '3',
 };
 

--- a/src/main/webapp/app/pages/curation/styles.module.scss
+++ b/src/main/webapp/app/pages/curation/styles.module.scss
@@ -1,3 +1,6 @@
 .textarea {
   min-height: 100px;
 }
+.summaryTextarea {
+  min-height: 20px;
+}

--- a/src/main/webapp/app/shared/firebase/input/RealtimeDropdownInput.tsx
+++ b/src/main/webapp/app/shared/firebase/input/RealtimeDropdownInput.tsx
@@ -7,7 +7,7 @@ import { ExtractPathExpressions } from '../../util/firebase/firebase-crud-store'
 import { Gene } from '../../model/firebase/firebase.model';
 import { IRootStore } from 'app/stores';
 import { inject } from 'mobx-react';
-import { getFirebasePath } from 'app/shared/util/firebase/firebase-utils';
+import { getFirebasePath, getValueByNestedKey } from 'app/shared/util/firebase/firebase-utils';
 import { RealtimeBasicLabel } from './RealtimeBasicInput';
 
 export interface IRealtimeDropdownInput extends SelectProps, StoreProps {
@@ -20,7 +20,10 @@ export interface IRealtimeDropdownInput extends SelectProps, StoreProps {
 const RealtimeDropdownInput = (props: IRealtimeDropdownInput) => {
   const { fieldKey, options, labelClass, label, updateReviewableContent, ...selectProps } = props;
 
-  const selectOptions = options.map(o => ({ label: o, value: o }));
+  const getOption = (val: string) => ({ label: val, value: val });
+  const selectOptions = options.map(getOption);
+  const defaultLevel = getValueByNestedKey(props.data, fieldKey);
+  const defaultOption = defaultLevel ? getOption(defaultLevel) : undefined;
 
   const onChangeHandler = (newValue, actionMeta) => {
     updateReviewableContent(getFirebasePath('GENE', props.data.name), fieldKey, newValue.value);
@@ -32,7 +35,7 @@ const RealtimeDropdownInput = (props: IRealtimeDropdownInput) => {
     <div className="flex d-flex mb-2">
       <div>{props.label && <RealtimeBasicLabel label={props.label} id={props.label} labelClass="mr-2 font-weight-bold" />}</div>
       <div className="flex-grow-1">
-        <Select {...selectProps} onChange={onChangeHandler} options={selectOptions} />
+        <Select {...selectProps} onChange={onChangeHandler} options={selectOptions} defaultValue={defaultOption} />
       </div>
     </div>
   );

--- a/src/main/webapp/app/shared/form/AutoParseRefField.tsx
+++ b/src/main/webapp/app/shared/form/AutoParseRefField.tsx
@@ -24,7 +24,7 @@ export const AutoParseRefField: React.FunctionComponent<IAutoParseRefField> = pr
 
   content = _.uniqBy(content, 'content');
 
-  return (
+  return content.length > 0 ? (
     <div className={'d-flex flex-wrap'}>
       <span>References:</span>
       {content.map(c => (
@@ -35,5 +35,7 @@ export const AutoParseRefField: React.FunctionComponent<IAutoParseRefField> = pr
         </span>
       ))}
     </div>
+  ) : (
+    <></>
   );
 };


### PR DESCRIPTION
- Open mutation effect/somatic/germline when mutation is opened
- Lower minimum height for summaries
- Display diagnostic/prognostic implication and summary
- Show default option in RealtimeDropdownInput if available