### PR TITLE
fix searching by main type

### DIFF
--- a/src/main/webapp/app/shared/modal/ModifyCancerTypeModal.tsx
+++ b/src/main/webapp/app/shared/modal/ModifyCancerTypeModal.tsx
@@ -61,8 +61,9 @@ const ModifyCancerTypeModalContent = observer(
 
     async function getICancerTypeFromCancerType(cancerType: CancerType) {
       try {
-        const iCancerType = await searchCancerTypes({ query: cancerType.subtype ? cancerType.code : cancerType.mainType });
-        return iCancerType['data'][0];
+        const isMainType = !cancerType.subtype;
+        const iCancerType = await searchCancerTypes({ query: isMainType ? cancerType.mainType : cancerType.code });
+        return isMainType ? iCancerType['data'].find(data => !data.subtype) : iCancerType['data'][0];
       } catch {
         modifyCancerTypeModalStore.setIsErrorFetchingICancerTypes(true);
         return null;


### PR DESCRIPTION
Fixed a bug where searching by main type would return all subtypes as well, causing the cancer type modal to display the first returned result (often a `subtype`) instead of the `mainType`. Now, after searching by `mainType`. the modal displays the result with no `subtype` (the correct `mainType`).