### PR TITLE
add comments to somatic and germline summary

### DIFF
--- a/src/main/webapp/app/pages/curation/CurationPage.tsx
+++ b/src/main/webapp/app/pages/curation/CurationPage.tsx
@@ -443,13 +443,47 @@ const CurationPage = (props: ICurationPageProps) => {
                 />
                 <RealtimeTextAreaInput
                   fieldKey="summary"
-                  label="Somatic Gene Summary"
-                  labelIcon={<GeneHistoryTooltip historyData={parsedHistoryList} location={'Gene Summary'} />}
+                  label="Somatic Gene Summary "
+                  labelIcon={
+                    <>
+                      <GeneHistoryTooltip historyData={parsedHistoryList} location={'Gene Summary'} />
+                      <div className="mr-3" />
+                      <CommentIcon
+                        id={props.data.summary_uuid}
+                        comments={props.data.summary_comments || []}
+                        onCreateComment={content =>
+                          handleCreateComment(`${firebaseGenePath}/summary_comments`, content, props.data.summary_comments?.length || 0)
+                        }
+                        onDeleteComments={indices => handleDeleteComments(`${firebaseGenePath}/summary_comments`, indices)}
+                        onResolveComment={index => handleResolveComment(`${firebaseGenePath}/summary_comments/${index}`)}
+                        onUnresolveComment={index => handleUnresolveComment(`${firebaseGenePath}/summary_comments/${index}`)}
+                      />
+                    </>
+                  }
                 />
                 <RealtimeTextAreaInput
                   fieldKey="germline_summary"
                   label="Germline Gene Summary"
-                  labelIcon={<GeneHistoryTooltip historyData={parsedHistoryList} location={'Germline Gene Summary'} />}
+                  labelIcon={
+                    <>
+                      <GeneHistoryTooltip historyData={parsedHistoryList} location={'Germline Gene Summary'} />
+                      <div className="mr-3" />
+                      <CommentIcon
+                        id={props.data.germline_summary_uuid}
+                        comments={props.data.germline_summary_comments || []}
+                        onCreateComment={content =>
+                          handleCreateComment(
+                            `${firebaseGenePath}/germline_summary_comments`,
+                            content,
+                            props.data.germline_summary_comments?.length || 0
+                          )
+                        }
+                        onDeleteComments={indices => handleDeleteComments(`${firebaseGenePath}/germline_summary_comments`, indices)}
+                        onResolveComment={index => handleResolveComment(`${firebaseGenePath}/germline_summary_comments/${index}`)}
+                        onUnresolveComment={index => handleUnresolveComment(`${firebaseGenePath}/germline_summary_comments/${index}`)}
+                      />
+                    </>
+                  }
                 />
               </Col>
             </Row>

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.spec.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.spec.ts
@@ -32,6 +32,7 @@ describe('Firebase Models', () => {
         summary_comments: [],
         germline_summary: '',
         germline_summary_uuid: DEFAULT_UUID,
+        germline_summary_comments: [],
         penetrance: '',
         penetrance_uuid: DEFAULT_UUID,
         type: new GeneType(),

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -136,6 +136,7 @@ export class Gene {
   germline_summary = '';
   germline_summary_review?: Review;
   germline_summary_uuid: string = generateUuid();
+  germline_summary_comments?: Comment[] = [];
   penetrance?: PENETRANCE | '' = '';
   penetrance_uuid? = generateUuid();
   penetrance_review?: Review;


### PR DESCRIPTION
We removed the gene summary section between the PR adding comments to the curation page and the latest rc. Therefore, we lost the gene summary comments and it's comments.

This PR maps those old comments to the somatic summary section. It also adds a `germline_summary_comments` to the `Gene` model and adds those to the germline comments section.