### PR TITLE
Show mutation stats except oncogenicity for mutations with multiple alterations and update checkbox styles

### DIFF
--- a/src/main/webapp/app/app.scss
+++ b/src/main/webapp/app/app.scss
@@ -394,3 +394,7 @@ http://stackoverflow.com/questions/23436430/bootstrap-3-input-group-100-width */
 .text-decoration-line-through {
   text-decoration: line-through;
 }
+
+.form-check-input {
+  margin-top: 0.1rem;
+}

--- a/src/main/webapp/app/pages/curation/collapsible/MutationCollapsible.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/MutationCollapsible.tsx
@@ -76,7 +76,7 @@ const MutationCollapsible = ({
 }: IMutationCollapsibleProps) => {
   const title = getMutationName(mutation);
   const mutationFirebasePath = buildFirebaseGenePath(hugoSymbol, `mutations/${firebaseIndex}`);
-  const showMutationLevelSummary = !title.includes(',');
+  const hideOncogenicityStat = title.includes(',');
 
   const [isEditingMutation, setIsEditingMutation] = useState(false);
 
@@ -147,7 +147,7 @@ const MutationCollapsible = ({
         className={'mb-1'}
         title={title}
         borderLeftColor={NestLevelColor[NestLevelMapping[NestLevelType.MUTATION]]}
-        info={showMutationLevelSummary ? <MutationLevelSummary mutationUuid={mutation.name_uuid} /> : null}
+        info={<MutationLevelSummary mutationUuid={mutation.name_uuid} hideOncogenicity={hideOncogenicityStat} />}
         action={
           <>
             <GeneHistoryTooltip key={'gene-history-tooltip'} historyData={parsedHistoryList} location={getMutationName(mutation)} />

--- a/src/main/webapp/app/pages/curation/collapsible/MutationCollapsible.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/MutationCollapsible.tsx
@@ -285,7 +285,7 @@ const MutationCollapsible = ({
           >
             {mutation.germline_genomic_indicators && (
               <div>
-                <b className="mb-2">Genomic Indicators: </b>
+                <b className="mb-2">Genomic Indicators </b>
                 <WithSeparator separator={', '}>
                   {mutation.germline_genomic_indicators?.map(indicator => {
                     return (

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/MutationLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/MutationLevelSummary.tsx
@@ -1,19 +1,19 @@
 import { componentInject } from 'app/shared/util/typed-inject';
 import { IRootStore } from 'app/stores';
-import { AllLevelSummary, MutationLevelSummary } from 'app/stores/firebase/firebase.gene.store';
+import { MutationLevelSummary } from 'app/stores/firebase/firebase.gene.store';
 import _ from 'lodash';
 import { observer } from 'mobx-react';
-import React, { useMemo } from 'react';
+import React from 'react';
 import NestLevelSummary from './NestLevelSummary';
-import { ONCOGENICITY } from 'app/config/constants/constants';
 
 export interface MutationLevelSummaryProps extends StoreProps {
   mutationUuid: string;
+  hideOncogenicity?: boolean;
 }
 
-const MutationLevelSummary = (props: MutationLevelSummaryProps) => {
-  const mutationLevelSummary = props.mutationSummaryStats[props.mutationUuid];
-  return <NestLevelSummary summaryStats={mutationLevelSummary} />;
+const MutationLevelSummary = ({ mutationSummaryStats, mutationUuid, hideOncogenicity = false }: MutationLevelSummaryProps) => {
+  const mutationLevelSummary = mutationSummaryStats[mutationUuid];
+  return <NestLevelSummary summaryStats={mutationLevelSummary} hideOncogenicity={hideOncogenicity} />;
 };
 
 const mapStoreToProps = ({ firebaseGeneStore }: IRootStore) => ({

--- a/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
+++ b/src/main/webapp/app/pages/curation/nestLevelSummary/NestLevelSummary.tsx
@@ -22,18 +22,19 @@ export type NestLevelSummaryStats = {
 
 export interface NestLevelSummaryProps {
   summaryStats: NestLevelSummaryStats;
+  hideOncogenicity?: boolean;
   isTreatmentStats?: boolean;
 }
 
-export const NestLevelSummary = (props: NestLevelSummaryProps) => {
+export const NestLevelSummary = ({ summaryStats, hideOncogenicity, isTreatmentStats }: NestLevelSummaryProps) => {
   const summaryKeys: (keyof NestLevelSummaryStats)[] = ['TTS', 'DxS', 'PxS'];
 
   let lastBadgeHasHiddenNumber = false;
 
-  const badges = props.summaryStats ? (
+  const badges = summaryStats ? (
     <>
-      {Object.keys(props.summaryStats)
-        .filter(k => props.summaryStats[k] && props.summaryStats[k] > 0)
+      {Object.keys(summaryStats)
+        .filter(k => summaryStats[k] && summaryStats[k] > 0)
         .map(k => {
           const hideWhenOne = summaryKeys.includes(k as keyof NestLevelSummaryStats);
           if (hideWhenOne) {
@@ -41,61 +42,61 @@ export const NestLevelSummary = (props: NestLevelSummaryProps) => {
           }
           return (
             <CountBadge
-              count={props.summaryStats[k]}
+              count={summaryStats[k]}
               base={k}
               key={`summaries-${k}`}
               hideWhenOne={summaryKeys.includes(k as keyof NestLevelSummaryStats)}
             />
           );
         })}
-      {Object.keys(props.summaryStats.txLevels)
+      {Object.keys(summaryStats.txLevels)
         .filter(k => k !== TX_LEVELS.LEVEL_NO)
         .sort(sortByTxLevel)
         .map(k => {
           lastBadgeHasHiddenNumber = false;
-          return props.isTreatmentStats ? (
+          return isTreatmentStats ? (
             <div key={`tx-levels-${k}`} className="count-badge-wrapper all-children-margin">
               <span className={classNames('oncokb', 'icon', `level-${k}`)}></span>
             </div>
           ) : (
             <CountBadge
-              count={props.summaryStats.txLevels[k]}
+              count={summaryStats.txLevels[k]}
               base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
               key={`tx-levels-${k}`}
             />
           );
         })}
-      {Object.keys(props.summaryStats.dxLevels)
+      {Object.keys(summaryStats.dxLevels)
         .sort()
         .map(k => {
           lastBadgeHasHiddenNumber = false;
           return (
             <CountBadge
-              count={props.summaryStats.dxLevels[k]}
+              count={summaryStats.dxLevels[k]}
               base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
               key={`dx-levels-${k}`}
             />
           );
         })}
-      {Object.keys(props.summaryStats.pxLevels)
+      {Object.keys(summaryStats.pxLevels)
         .sort()
         .map(k => {
           lastBadgeHasHiddenNumber = false;
           return (
             <CountBadge
-              count={props.summaryStats.pxLevels[k]}
+              count={summaryStats.pxLevels[k]}
               base={<span className={classNames('oncokb', 'icon', `level-${k}`)}></span>}
               key={`px-levels-${k}`}
             />
           );
         })}
-      {props.summaryStats.oncogenicity ? (
+      {!hideOncogenicity && summaryStats.oncogenicity ? (
         <CountBadge
           hideWhenOne
           count={1}
           base={
-            <DefaultTooltip placement="top" overlay={<span>{FIREBASE_ONCOGENICITY_MAPPING[props.summaryStats.oncogenicity]}</span>}>
-              <span className={classNames('oncokb', 'icon', `${ONCOGENICITY_CLASS_MAPPING[props.summaryStats.oncogenicity]}`)}></span>
+            <DefaultTooltip placement="top" overlay={<span>{FIREBASE_ONCOGENICITY_MAPPING[summaryStats.oncogenicity]}</span>}>
+              <span className={classNames('oncokb', 'icon', `${ONCOGENICITY_CLASS_MAPPING[summaryStats.oncogenicity]}`)}></span>
             </DefaultTooltip>
           }
         />
@@ -105,11 +106,11 @@ export const NestLevelSummary = (props: NestLevelSummaryProps) => {
     <></>
   );
 
-  if (props.summaryStats?.oncogenicity) {
+  if (summaryStats?.oncogenicity) {
     lastBadgeHasHiddenNumber = true;
   }
 
-  if (props.summaryStats) {
+  if (summaryStats) {
     return <div className={classNames('d-flex align-items-center all-children-margin')}>{badges}</div>;
   }
   return <div></div>;

--- a/src/main/webapp/app/shared/firebase/input/FirebaseRealtimeInput.tsx
+++ b/src/main/webapp/app/shared/firebase/input/FirebaseRealtimeInput.tsx
@@ -54,17 +54,17 @@ export interface IRealtimeCheckedInputGroup {
 
 export const RealtimeCheckedInputGroup = (props: IRealtimeCheckedInputGroup) => {
   return (
-    <div className="flex d-flex">
-      <span className="font-weight-bold text-nowrap">{props.groupHeader}:</span>
-      <span className="d-flex flex-wrap">
+    <div className="mb-2">
+      <div className="d-flex align-items-center font-weight-bold text-nowrap">{props.groupHeader}</div>
+      <div className="d-flex flex-wrap">
         {props.options.map(option => {
           return props.isRadio ? (
-            <RealtimeRadioInput key={option.label} fieldKey={option.fieldKey} className="ml-2" label={option.label} />
+            <RealtimeRadioInput key={option.label} fieldKey={option.fieldKey} className="mr-2" label={option.label} />
           ) : (
-            <RealtimeCheckboxInput key={option.label} fieldKey={option.fieldKey} className="ml-2" label={option.label} />
+            <RealtimeCheckboxInput key={option.label} fieldKey={option.fieldKey} className="mr-2" label={option.label} />
           );
         })}
-      </span>
+      </div>
     </div>
   );
 };

--- a/src/main/webapp/app/shared/firebase/input/RealtimeBasicInput.tsx
+++ b/src/main/webapp/app/shared/firebase/input/RealtimeBasicInput.tsx
@@ -68,7 +68,7 @@ const RealtimeBasicInput: React.FunctionComponent<IRealtimeBasicInput> = (props:
   const isInlineInputText = type === RealtimeInputType.INLINE_TEXT;
 
   const labelComponent = label && (
-    <RealtimeBasicLabel label={label} labelIcon={labelIcon} id={id} labelClass={isCheckType ? '' : 'font-weight-bold'} />
+    <RealtimeBasicLabel label={label} labelIcon={labelIcon} id={id} labelClass={isCheckType ? 'mb-0' : 'font-weight-bold'} />
   );
 
   const inputValue = getValueByNestedKey(data, fieldKey);
@@ -99,8 +99,13 @@ const RealtimeBasicInput: React.FunctionComponent<IRealtimeBasicInput> = (props:
     </Input>
   );
 
+  const checkTypeCss: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+  };
+
   return (
-    <div className={classNames('mb-2', className)}>
+    <div className={classNames(!isCheckType ? 'mb-2' : undefined, className)} style={isCheckType ? checkTypeCss : undefined}>
       {isCheckType ? (
         <>
           {inputComponent}


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb-pipeline/issues/256 and is related to https://github.com/oncokb/oncokb-pipeline/issues/244

Currently, don't show oncogenicity (but show other stats) when mutation has multiple alterations. I omitted the change to show unknown oncogenicity because I need some logic from Ben's PR to check if the alteration is a positional variant. I can follow up with another PR.

Updated style for checkbox/radios:
- Centered the labels
- Centered the checkbox/radio with the text to the right

I adjusted the checkboxes to go under the label instead of inline. The inline saves 1 line of space, but I didn't think it would make that much of a difference. It also makes it consistent with all the other input types. Let me know if I should revert.
![image](https://github.com/oncokb/oncokb-transcript/assets/59149377/dcc1d235-10fe-4864-ba0e-57a28757bacd)
