### PR TITLE
Support parsing simple c. and g. alteration

### DIFF
--- a/src/main/webapp/app/shared/modal/AddMutationModal.tsx
+++ b/src/main/webapp/app/shared/modal/AddMutationModal.tsx
@@ -75,6 +75,7 @@ function AddMutationModal({
     AlterationTypeEnum.CopyNumberAlteration,
     AlterationTypeEnum.StructuralVariant,
     AlterationTypeEnum.CdnaChange,
+    AlterationTypeEnum.GenomicChange,
     AlterationTypeEnum.Any,
   ].map(type => ({ label: READABLE_ALTERATION[type], value: type }));
   const consequenceOptions: DropdownOption[] = consequences.map(consequence => ({ label: consequence.name, value: consequence.id }));
@@ -626,6 +627,8 @@ function AddMutationModal({
         content = getProteinChangeContent(alterationData, alterationIndex, excludingIndex);
         break;
       case AlterationTypeEnum.CopyNumberAlteration:
+      case AlterationTypeEnum.CdnaChange:
+      case AlterationTypeEnum.GenomicChange:
         content = getCopyNumberAlterationContent(alterationData, alterationIndex, excludingIndex);
         break;
       case AlterationTypeEnum.StructuralVariant:


### PR DESCRIPTION
The following formats will be supported.
- c.*
- g.*
- ([0-9]{1,2}|X|Y|MT):g.*

Technically c. and g. variants will have reference allele and variant allele, but that will be supported in the future.
<img width="493" alt="Screenshot 2024-05-01 at 12 43 09 AM" src="https://github.com/oncokb/oncokb-transcript/assets/5400599/554d017f-5e45-42cd-9b93-76b461d8a8fe">
<img width="489" alt="Screenshot 2024-05-01 at 12 43 18 AM" src="https://github.com/oncokb/oncokb-transcript/assets/5400599/29296295-4ae4-4e9a-ba97-0776507d598b">
<img width="485" alt="Screenshot 2024-05-01 at 12 54 49 AM" src="https://github.com/oncokb/oncokb-transcript/assets/5400599/ad9ecb6e-9085-4434-bc79-bd1a0746df75">
