### PR TITLE
Disable SV genes field

### DIFF
--- a/src/main/webapp/app/shared/modal/AddMutationModal.tsx
+++ b/src/main/webapp/app/shared/modal/AddMutationModal.tsx
@@ -756,6 +756,7 @@ function AddMutationModal({
           label="Genes"
           value={alterationData.genes?.map(gene => gene.hugoSymbol).join(', ')}
           placeholder="Input genes"
+          disabled
           onChange={newValue => handleFieldChange(newValue, 'genes', alterationIndex, excludingIndex)}
         />
       </div>
@@ -1026,9 +1027,10 @@ interface IAddMutationModalFieldProps {
   placeholder: string;
   onChange: (newValue: string) => void;
   isLoading?: boolean;
+  disabled?: boolean;
 }
 
-function AddMutationModalField({ label, value: value, placeholder, onChange, isLoading }: IAddMutationModalFieldProps) {
+function AddMutationModalField({ label, value: value, placeholder, onChange, isLoading, disabled }: IAddMutationModalFieldProps) {
   return (
     <Row className="align-items-center mb-3">
       <Col className="px-0 col-3 mr-3 align-items-center">
@@ -1039,6 +1041,7 @@ function AddMutationModalField({ label, value: value, placeholder, onChange, isL
       </Col>
       <Col className="px-0">
         <Input
+          disabled={disabled}
           value={value}
           onChange={event => {
             onChange(event.target.value);


### PR DESCRIPTION
Modifying the Genes input field is not feasible. The proper solution should be to change it to GeneSelect. But using GeneSelect requires significant work which will be dealt with in https://github.com/oncokb/oncokb-pipeline/issues/347

This fixes https://github.com/oncokb/oncokb-pipeline/issues/343