### PR TITLE
Check geneEntity before rendering

### DIFF
--- a/src/main/webapp/app/pages/curation/CurationPage.tsx
+++ b/src/main/webapp/app/pages/curation/CurationPage.tsx
@@ -123,7 +123,7 @@ export const CurationPage = (props: ICurationPageProps) => {
     </Row>
   );
 
-  return props.firebaseInitSuccess && !props.loadingGenes && props.drugList.length > 0 ? (
+  return props.firebaseInitSuccess && !props.loadingGenes && props.drugList.length > 0 && !!geneEntity ? (
     isReviewing ? (
       <div>
         {geneHeader}


### PR DESCRIPTION
This is a followup to https://github.com/oncokb/oncokb-transcript/pull/321.

Introduced a bug in above PR where the geneEntity is passed as undefined.
