### PR TITLE
Check history has records

### DIFF
--- a/src/main/webapp/app/shared/util/firebase/firebase-history-utils.ts
+++ b/src/main/webapp/app/shared/util/firebase/firebase-history-utils.ts
@@ -81,7 +81,7 @@ export type FlattenedHistory = HistoryRecord & Omit<History, 'records'>;
 export const parseHistory = (history: HistoryList, drugList: readonly IDrug[]) => {
   const parsedHistory: FlattenedHistory[] = []; // ADD TYPE
   for (const historyEntry of Object.values(history)) {
-    if (Symbol.iterator in historyEntry.records) {
+    if (historyEntry.records && Symbol.iterator in historyEntry.records) {
       const parsedRecords: HistoryRecord[] = [];
 
       for (const record of historyEntry.records) {


### PR DESCRIPTION
This fix allows the user to go into the gene page if the history does not have record. The history without record was introduced(I think) during the review which we still need to figure out how it happened.

This is related to https://github.com/oncokb/oncokb-pipeline/issues/401