### PR TITLE
Fix tumor name review logic

### DIFF
--- a/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
+++ b/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
@@ -58,7 +58,7 @@ const ReviewPage = (props: IReviewPageProps) => {
       let uuids = [];
       for (const key of Object.keys(metaReview)) {
         if (metaReview[key] === true) {
-          uuids = uuids.concat(key.split(', '));
+          uuids = uuids.concat(key.split(', ').map(uuid => uuid.trim()));
         }
       }
       setReviewUuids(uuids);

--- a/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
+++ b/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
@@ -16,7 +16,6 @@ import { observer } from 'mobx-react';
 import React, { useEffect, useState } from 'react';
 import { Alert, Button, Col, FormGroup, Input, Label, Row } from 'reactstrap';
 import { ReviewCollapsible } from '../collapsible/ReviewCollapsible';
-import _ from 'lodash';
 
 interface IReviewPageProps extends StoreProps {
   hugoSymbol: string;

--- a/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
+++ b/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
@@ -58,7 +58,7 @@ const ReviewPage = (props: IReviewPageProps) => {
       let uuids = [];
       for (const key of Object.keys(metaReview)) {
         if (metaReview[key] === true) {
-          uuids = uuids.concat(key.split(', ').map(uuid => uuid.trim()));
+          uuids = uuids.concat(key.split(',').map(uuid => uuid.trim()));
         }
       }
       setReviewUuids(uuids);

--- a/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
+++ b/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
@@ -16,6 +16,7 @@ import { observer } from 'mobx-react';
 import React, { useEffect, useState } from 'react';
 import { Alert, Button, Col, FormGroup, Input, Label, Row } from 'reactstrap';
 import { ReviewCollapsible } from '../collapsible/ReviewCollapsible';
+import _ from 'lodash';
 
 interface IReviewPageProps extends StoreProps {
   hugoSymbol: string;
@@ -55,10 +56,10 @@ const ReviewPage = (props: IReviewPageProps) => {
 
   useEffect(() => {
     if (metaReview) {
-      const uuids = [];
+      let uuids = [];
       for (const key of Object.keys(metaReview)) {
         if (metaReview[key] === true) {
-          uuids.push(key);
+          uuids = uuids.concat(key.split(', '));
         }
       }
       setReviewUuids(uuids);

--- a/src/main/webapp/app/service/firebase/firebase-gene-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-service.ts
@@ -295,12 +295,6 @@ export class FirebaseGeneService {
       }
       this.firebaseMetaService.updateGeneMetaContent(hugoSymbol, false);
       this.firebaseMetaService.updateGeneReviewUuid(hugoSymbol, tumorNameUuid, !isChangeReverted, false);
-      // this.firebaseMetaService.updateGeneReviewUuid(
-      //   hugoSymbol,
-      //   tumor.excludedCancerTypes_uuid,
-      //   !excludedCancerTypesReview.isChangeReverted,
-      //   false,
-      // );
     });
   };
 

--- a/src/main/webapp/app/service/firebase/firebase-gene-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-service.ts
@@ -259,9 +259,11 @@ export class FirebaseGeneService {
     const name = this.authStore.fullName;
     newTumor.cancerTypes_review = new Review(name, undefined, true, undefined);
 
+    const tumorNameUuid = `${newTumor.cancerTypes_uuid}, ${newTumor.excludedCancerTypes_uuid}`;
+
     return this.firebaseRepository.pushToArray(tumorPath, [newTumor]).then(() => {
       this.firebaseMetaService.updateGeneMetaContent(hugoSymbol, false);
-      this.firebaseMetaService.updateGeneReviewUuid(hugoSymbol, newTumor.cancerTypes_uuid, true, false);
+      this.firebaseMetaService.updateGeneReviewUuid(hugoSymbol, tumorNameUuid, true, false);
     });
   };
 
@@ -277,6 +279,11 @@ export class FirebaseGeneService {
     tumor.cancerTypes_review = cancerTypesReview.updatedReview;
     tumor.excludedCancerTypes_review = excludedCancerTypesReview.updatedReview;
 
+    const isChangeReverted = cancerTypesReview.isChangeReverted || excludedCancerTypesReview.isChangeReverted;
+    // The legacy platform combines the uuid of cancerTypes and excludedCancerTypes in review mode.
+    // To maintain compatibility, we will do the same here.
+    const tumorNameUuid = `${tumor.cancerTypes_uuid}, ${tumor.excludedCancerTypes_uuid}`;
+
     const { hugoSymbol } = parseFirebaseGenePath(tumorPath);
 
     return this.firebaseRepository.update(tumorPath, tumor).then(() => {
@@ -287,13 +294,13 @@ export class FirebaseGeneService {
         this.firebaseRepository.delete(`${tumorPath}/excludedCancerTypes_review/lastReviewed`);
       }
       this.firebaseMetaService.updateGeneMetaContent(hugoSymbol, false);
-      this.firebaseMetaService.updateGeneReviewUuid(hugoSymbol, tumor.cancerTypes_uuid, !cancerTypesReview.isChangeReverted, false);
-      this.firebaseMetaService.updateGeneReviewUuid(
-        hugoSymbol,
-        tumor.excludedCancerTypes_uuid,
-        !excludedCancerTypesReview.isChangeReverted,
-        false,
-      );
+      this.firebaseMetaService.updateGeneReviewUuid(hugoSymbol, tumorNameUuid, !isChangeReverted, false);
+      // this.firebaseMetaService.updateGeneReviewUuid(
+      //   hugoSymbol,
+      //   tumor.excludedCancerTypes_uuid,
+      //   !excludedCancerTypesReview.isChangeReverted,
+      //   false,
+      // );
     });
   };
 


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb-pipeline/issues/405

Issues fixed:
1. Split meta uuid by `, ` to support cancer type added/updated through legacy.
2. Excluded cancer type field not cleared after accepting/rejecting