### PR TITLE
Remove all nested reviewables when deleting without review

### DIFF
--- a/src/main/webapp/app/pages/curation/collapsible/CancerTypeCollapsible.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/CancerTypeCollapsible.tsx
@@ -2,7 +2,7 @@ import { CancerType, Review } from 'app/shared/model/firebase/firebase.model';
 import { componentInject } from 'app/shared/util/typed-inject';
 import { getCancerTypesNameWithExclusion } from 'app/shared/util/utils';
 import { IRootStore } from 'app/stores';
-import { onValue, ref } from 'firebase/database';
+import { get, onValue, ref } from 'firebase/database';
 import { observer } from 'mobx-react';
 import React, { useEffect, useState } from 'react';
 import GeneHistoryTooltip from 'app/components/geneHistoryTooltip/GeneHistoryTooltip';
@@ -81,6 +81,11 @@ function CancerTypeCollapsible({
     return () => callbacks.forEach(callback => callback?.());
   }, [cancerTypePath, firebaseDb]);
 
+  async function handleDeleteCancerType() {
+    const snapshot = await get(ref(firebaseDb, cancerTypePath));
+    deleteSection(`${cancerTypePath}/cancerTypes`, snapshot.val(), cancerTypesReview, cancerTypesUuid);
+  }
+
   if (!cancerTypes || !cancerTypesUuid) {
     return <></>;
   }
@@ -110,7 +115,7 @@ function CancerTypeCollapsible({
             />
             <DeleteSectionButton
               sectionName={cancerTypeName}
-              deleteHandler={() => deleteSection(`${cancerTypePath}/cancerTypes`, cancerTypesReview, cancerTypesUuid)}
+              deleteHandler={handleDeleteCancerType}
               isRemovableWithoutReview={isRemovableWithoutReview}
             />
           </>

--- a/src/main/webapp/app/pages/curation/collapsible/TherapyCollapsible.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/TherapyCollapsible.tsx
@@ -10,7 +10,7 @@ import { FlattenedHistory } from 'app/shared/util/firebase/firebase-history-util
 import { getTxName, isSectionRemovableWithoutReview } from 'app/shared/util/firebase/firebase-utils';
 import { componentInject } from 'app/shared/util/typed-inject';
 import { IRootStore } from 'app/stores';
-import { onValue, ref } from 'firebase/database';
+import { get, onValue, ref } from 'firebase/database';
 import { observer } from 'mobx-react';
 import React, { useEffect, useState } from 'react';
 import BadgeGroup from '../BadgeGroup';
@@ -71,6 +71,11 @@ function TherapyCollapsible({
     );
   }, [therapyPath, firebaseDb]);
 
+  async function handleDeleteTherapy() {
+    const snapshot = await get(ref(firebaseDb, therapyPath));
+    deleteSection(`${therapyPath}/name`, snapshot.val(), treatmentReview, treatmentUuid);
+  }
+
   if (!treatmentUuid || !treatmentName) {
     return <></>;
   }
@@ -96,7 +101,7 @@ function TherapyCollapsible({
             />
             <DeleteSectionButton
               sectionName={cancerTypeName}
-              deleteHandler={() => deleteSection(`${therapyPath}/name`, treatmentReview, treatmentUuid)}
+              deleteHandler={handleDeleteTherapy}
               isRemovableWithoutReview={isRemovableWithoutReview}
             />
           </>

--- a/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
@@ -798,3 +798,16 @@ export const getUpdatedReview = (oldReview: Review, currentValue: any, newValue:
 
   return { updatedReview: oldReview, isChangeReverted };
 };
+
+export const hasReview = (review: Review) => {
+  if (review.lastReviewed === '' || !_.isEmpty(review.lastReviewed)) {
+    return true;
+  }
+  const reviewableKeys: (keyof Review)[] = ['added', 'promotedToMutation', 'removed', 'demotedToVus', 'initialUpdate'];
+  for (const key of reviewableKeys) {
+    if (review[key] === true) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
@@ -27,6 +27,7 @@ import { replaceUrlParams } from '../url-utils';
 import { extractPositionFromSingleNucleotideAlteration, isUuid, parseAlterationName } from '../utils';
 import { isTxLevelPresent } from './firebase-level-utils';
 import { parseFirebaseGenePath } from './firebase-path-utils';
+import { hasReview } from './firebase-review-utils';
 
 export const getValueByNestedKey = (obj: any, nestedKey = '') => {
   return nestedKey.split('/').reduce((currObj, currKey) => {
@@ -784,3 +785,27 @@ export const getReviewInfo = (editor: string, action: string, updateTime?: strin
 export const getAllCommentsString = (comments: Comment[]) => {
   return comments.map(comment => comment.content).join('\n');
 };
+
+export function findNestedUuids(obj: any, uuids: string[] = []) {
+  // Base case: if the input is not an object, return
+  if (typeof obj !== 'object' || obj === null) {
+    return uuids;
+  }
+
+  // Iterate through each key in the object
+  for (const key of Object.keys(obj)) {
+    if (key.endsWith('_review') && hasReview(obj[key])) {
+      // If the key ends with "_review" and has reviewable content, add the corresponding "_uuid" key to the result array
+      const uuidKey = key.slice(0, -7) + '_uuid';
+      if (obj[uuidKey]) {
+        uuids.push(obj[uuidKey]);
+      }
+    }
+    // If the value is an object, recursively call the function
+    if (typeof obj[key] === 'object') {
+      findNestedUuids(obj[key], uuids);
+    }
+  }
+
+  return uuids;
+}


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb-pipeline/issues/409

Issue:
When a mutation/ct/therapy/genomic indicator is created, we allow the user to delete without review via the delete button on curation page. If the newly created object has data (ie. mutation effect), then we also need to clear the nested uuids from meta collection.