### PR TITLE
Fda level saved in firebase should have prefix except for no level

### DIFF
--- a/src/main/webapp/app/config/constants/firebase.ts
+++ b/src/main/webapp/app/config/constants/firebase.ts
@@ -122,24 +122,6 @@ export const PATHOGENICITY_OPTIONS = [
   PATHOGENICITY.BENIGN,
 ];
 
-/**
- * We need this enum because FDA_LEVELS enum has the same value as TX_LEVELS enum.
- * We cannot directly change FDA_LEVELS.LEVEL_FDA1 to 'Fda1' because we don't want to update firebase yet.
- */
-export enum FDA_LEVEL_KEYS {
-  LEVEL_FDA1 = 'Fda1',
-  LEVEL_FDA2 = 'Fda2',
-  LEVEL_FDA3 = 'Fda3',
-  LEVEL_FDA_NO = 'FdaNo',
-}
-
-export const FDA_LEVEL_KEYS_MAPPING: { [key in FDA_LEVEL_KEYS]: FDA_LEVELS } = {
-  [FDA_LEVEL_KEYS.LEVEL_FDA1]: FDA_LEVELS.LEVEL_FDA1,
-  [FDA_LEVEL_KEYS.LEVEL_FDA2]: FDA_LEVELS.LEVEL_FDA2,
-  [FDA_LEVEL_KEYS.LEVEL_FDA3]: FDA_LEVELS.LEVEL_FDA3,
-  [FDA_LEVEL_KEYS.LEVEL_FDA_NO]: FDA_LEVELS.LEVEL_FDA_NO,
-};
-
 export const THERAPEUTIC_SENSITIVE_LEVELS = [
   TX_LEVELS.LEVEL_1,
   TX_LEVELS.LEVEL_2,
@@ -164,7 +146,7 @@ export const PROGNOSTIC_LEVELS_ORDERING = [PX_LEVELS.LEVEL_PX1, PX_LEVELS.LEVEL_
 
 export const DIAGNOSTIC_LEVELS_ORDERING = [DX_LEVELS.LEVEL_DX1, DX_LEVELS.LEVEL_DX2, DX_LEVELS.LEVEL_DX3];
 
-export const FDA_LEVELS_ORDERING = [FDA_LEVEL_KEYS.LEVEL_FDA1, FDA_LEVEL_KEYS.LEVEL_FDA2, FDA_LEVEL_KEYS.LEVEL_FDA3];
+export const FDA_LEVELS_ORDERING = [FDA_LEVELS.LEVEL_FDA1, FDA_LEVELS.LEVEL_FDA2, FDA_LEVELS.LEVEL_FDA3];
 
 export const ALL_LEVELS = [
   ...THERAPEUTIC_LEVELS_ORDERING,
@@ -215,11 +197,11 @@ export const DX_LEVEL_DESCRIPTIONS: { [key in DX_LEVELS]: string } = {
   [DX_LEVELS.LEVEL_DX3]: 'Biomarker that may assist disease diagnosis in this indication based on clinical evidence',
 };
 
-export const FDA_LEVEL_DESCRIPTIONS: { [key in FDA_LEVEL_KEYS]: string } = {
-  [FDA_LEVEL_KEYS.LEVEL_FDA1]: 'Companion Diagnostics',
-  [FDA_LEVEL_KEYS.LEVEL_FDA2]: 'Cancer Mutations with Evidence of Clinical Significance',
-  [FDA_LEVEL_KEYS.LEVEL_FDA3]: 'Cancer Mutations with Potential of Clinical Significance',
-  [FDA_LEVEL_KEYS.LEVEL_FDA_NO]: 'No level',
+export const FDA_LEVEL_DESCRIPTIONS: { [key in FDA_LEVELS]: string } = {
+  [FDA_LEVELS.LEVEL_FDA1]: 'Companion Diagnostics',
+  [FDA_LEVELS.LEVEL_FDA2]: 'Cancer Mutations with Evidence of Clinical Significance',
+  [FDA_LEVELS.LEVEL_FDA3]: 'Cancer Mutations with Potential of Clinical Significance',
+  [FDA_LEVELS.LEVEL_FDA_NO]: 'No level',
 };
 
 export const ALL_LEVEL_DESCRIPTIONS = {

--- a/src/main/webapp/app/pages/curation/collapsible/TherapyDropdownGroup.tsx
+++ b/src/main/webapp/app/pages/curation/collapsible/TherapyDropdownGroup.tsx
@@ -1,6 +1,5 @@
-import { FDA_LEVEL_KEYS } from 'app/config/constants/firebase';
 import { RealtimeDropdownOptions } from 'app/shared/firebase/input/RealtimeDropdownInput';
-import { TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
+import { FDA_LEVELS, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
 import {
   getFdaPropagationInfo,
   getPropagatedLevelDropdownOptions,
@@ -31,7 +30,7 @@ const PLACEHOLDER = 'You must select a level';
 const TherapyDropdownGroup = ({ firebaseDb, treatmentPath }: ITherapyDropdownGroup) => {
   const [highestLevel, setHighestLevel] = useState<TX_LEVELS>(null);
   const [propOptions, setPropOptions] = useState<RealtimeDropdownOptions[]>(null);
-  const [propFdaLevel, setPropFdaLevel] = useState<FDA_LEVEL_KEYS>(null);
+  const [propFdaLevel, setPropFdaLevel] = useState<FDA_LEVELS>(null);
   const [propFdaOptions, setPropFdaOptions] = useState<RealtimeDropdownOptions[]>(null);
   const [isPropagationLevelsDisabled, setIsPropagationLevelsDisabled] = useState(true);
   const [isFdaPropagationLevelDisabled, setIsFdaPropagationLevelDisabled] = useState(true);
@@ -41,7 +40,7 @@ const TherapyDropdownGroup = ({ firebaseDb, treatmentPath }: ITherapyDropdownGro
     callbacks.push(
       onValue(ref(firebaseDb, `${treatmentPath}/level`), snapshot => {
         setHighestLevel(snapshot.val());
-      })
+      }),
     );
     return () => {
       callbacks.forEach(callback => callback?.());
@@ -55,7 +54,7 @@ const TherapyDropdownGroup = ({ firebaseDb, treatmentPath }: ITherapyDropdownGro
     setPropOptions(getPropagatedLevelDropdownOptions(highestLevel));
 
     const fdaPropagation = getFdaPropagationInfo(highestLevel);
-    setPropFdaLevel(fdaPropagation.defaultPropagation as FDA_LEVEL_KEYS);
+    setPropFdaLevel(fdaPropagation.defaultPropagation as FDA_LEVELS);
     setPropFdaOptions(fdaPropagation.dropdownOptions);
   }, [highestLevel]);
 

--- a/src/main/webapp/app/shared/icons/FdaLevelIcon.tsx
+++ b/src/main/webapp/app/shared/icons/FdaLevelIcon.tsx
@@ -1,11 +1,11 @@
-import { FDA_LEVEL_KEYS } from 'app/config/constants/firebase';
 import React from 'react';
 import { faCircle as farCircle } from '@fortawesome/free-regular-svg-icons';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { FDA_LEVELS } from '../model/firebase/firebase.model';
 
 export interface IFdaLevelIcon {
-  level: FDA_LEVEL_KEYS;
+  level: FDA_LEVELS;
 }
 
 export const FdaLevelIcon = (props: IFdaLevelIcon) => {

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -66,10 +66,10 @@ export enum PX_LEVELS {
 }
 
 export enum FDA_LEVELS {
-  LEVEL_FDA1 = '1',
-  LEVEL_FDA2 = '2',
-  LEVEL_FDA3 = '3',
-  LEVEL_FDA_NO = 'no',
+  LEVEL_FDA1 = 'Fda1',
+  LEVEL_FDA2 = 'Fda2',
+  LEVEL_FDA3 = 'Fda3',
+  LEVEL_FDA_NO = 'FdaNo',
 }
 
 // In future, we want to remove the TI Types because they distinguishable

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -69,7 +69,7 @@ export enum FDA_LEVELS {
   LEVEL_FDA1 = 'Fda1',
   LEVEL_FDA2 = 'Fda2',
   LEVEL_FDA3 = 'Fda3',
-  LEVEL_FDA_NO = 'FdaNo',
+  LEVEL_FDA_NO = 'no',
 }
 
 // In future, we want to remove the TI Types because they distinguishable

--- a/src/main/webapp/app/shared/text/LevelWithDescription.tsx
+++ b/src/main/webapp/app/shared/text/LevelWithDescription.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { LEVELS, ONCOKB_LEVELS } from '../util/firebase/firebase-level-utils';
-import { ALL_LEVEL_DESCRIPTIONS, FDA_LEVEL_KEYS } from 'app/config/constants/firebase';
+import { ALL_LEVEL_DESCRIPTIONS } from 'app/config/constants/firebase';
 import { FdaLevelIcon } from '../icons/FdaLevelIcon';
-import { TX_LEVELS } from '../model/firebase/firebase.model';
+import { FDA_LEVELS, TX_LEVELS } from '../model/firebase/firebase.model';
 import { OncoKBIcon } from '../icons/OncoKBIcon';
 
 export interface ILevelWithDescriptionProps {
@@ -11,10 +11,10 @@ export interface ILevelWithDescriptionProps {
 
 export const LevelWithDescription = (props: ILevelWithDescriptionProps) => {
   let levelIcon = <OncoKBIcon iconType="level" value={props.level as ONCOKB_LEVELS} />;
-  if (Object.values(FDA_LEVEL_KEYS).includes(props.level as FDA_LEVEL_KEYS)) {
-    levelIcon = <FdaLevelIcon level={props.level as FDA_LEVEL_KEYS} />;
+  if (Object.values(FDA_LEVELS).includes(props.level as FDA_LEVELS)) {
+    levelIcon = <FdaLevelIcon level={props.level as FDA_LEVELS} />;
   }
-  if (props.level === FDA_LEVEL_KEYS.LEVEL_FDA_NO || props.level === TX_LEVELS.LEVEL_NO || props.level === TX_LEVELS.LEVEL_EMPTY) {
+  if (props.level === FDA_LEVELS.LEVEL_FDA_NO || props.level === TX_LEVELS.LEVEL_NO || props.level === TX_LEVELS.LEVEL_EMPTY) {
     levelIcon = <></>;
   }
   return (

--- a/src/main/webapp/app/shared/util/firebase/firebase-level-utils.spec.ts
+++ b/src/main/webapp/app/shared/util/firebase/firebase-level-utils.spec.ts
@@ -1,17 +1,16 @@
-import { FDA_LEVEL_KEYS } from 'app/config/constants/firebase';
 import { FDA_LEVELS, TX_LEVELS } from 'app/shared/model/firebase/firebase.model';
-import { convertToFdaLevelKey, getFdaPropagationInfo, getPropagatedLevelDropdownOptions } from './firebase-level-utils';
+import { getFdaPropagationInfo, getPropagatedLevelDropdownOptions } from './firebase-level-utils';
 import { isBetweenDates } from './firebase-history-utils';
 
 describe('Firebase Level Utils', () => {
   describe('convertToFdaLevelKey', () => {
     test.each([
-      { fdaLevel: FDA_LEVELS.LEVEL_FDA1, expected: FDA_LEVEL_KEYS.LEVEL_FDA1 },
-      { fdaLevel: FDA_LEVELS.LEVEL_FDA2, expected: FDA_LEVEL_KEYS.LEVEL_FDA2 },
-      { fdaLevel: FDA_LEVELS.LEVEL_FDA3, expected: FDA_LEVEL_KEYS.LEVEL_FDA3 },
-      { fdaLevel: FDA_LEVELS.LEVEL_FDA_NO, expected: FDA_LEVEL_KEYS.LEVEL_FDA_NO },
+      { fdaLevel: FDA_LEVELS.LEVEL_FDA1, expected: FDA_LEVELS.LEVEL_FDA1 },
+      { fdaLevel: FDA_LEVELS.LEVEL_FDA2, expected: FDA_LEVELS.LEVEL_FDA2 },
+      { fdaLevel: FDA_LEVELS.LEVEL_FDA3, expected: FDA_LEVELS.LEVEL_FDA3 },
+      { fdaLevel: FDA_LEVELS.LEVEL_FDA_NO, expected: FDA_LEVELS.LEVEL_FDA_NO },
     ])('should convert $fdaLevel to $expected', ({ fdaLevel, expected }) => {
-      expect(convertToFdaLevelKey(fdaLevel)).toEqual(expected);
+      expect(fdaLevel).toEqual(expected);
     });
   });
 
@@ -20,22 +19,18 @@ describe('Firebase Level Utils', () => {
       'should return FDA levels 2, 3 and no when highest level is %s',
       txLevel => {
         const { dropdownOptions, defaultPropagation } = getFdaPropagationInfo(txLevel);
-        expect(defaultPropagation).toEqual(FDA_LEVEL_KEYS.LEVEL_FDA2);
-        expect(dropdownOptions.map(o => o.value)).toStrictEqual([
-          FDA_LEVEL_KEYS.LEVEL_FDA2,
-          FDA_LEVEL_KEYS.LEVEL_FDA3,
-          FDA_LEVEL_KEYS.LEVEL_FDA_NO,
-        ]);
-      }
+        expect(defaultPropagation).toEqual(FDA_LEVELS.LEVEL_FDA2);
+        expect(dropdownOptions.map(o => o.value)).toStrictEqual([FDA_LEVELS.LEVEL_FDA2, FDA_LEVELS.LEVEL_FDA3, FDA_LEVELS.LEVEL_FDA_NO]);
+      },
     );
 
     test.each([[TX_LEVELS.LEVEL_3B], [TX_LEVELS.LEVEL_4], [TX_LEVELS.LEVEL_R2]])(
       'should return FDA levels 3 and no when highest level is %s',
       txLevel => {
         const { dropdownOptions, defaultPropagation } = getFdaPropagationInfo(txLevel);
-        expect(defaultPropagation).toEqual(FDA_LEVEL_KEYS.LEVEL_FDA3);
-        expect(dropdownOptions.map(o => o.value)).toStrictEqual([FDA_LEVEL_KEYS.LEVEL_FDA3, FDA_LEVEL_KEYS.LEVEL_FDA_NO]);
-      }
+        expect(defaultPropagation).toEqual(FDA_LEVELS.LEVEL_FDA3);
+        expect(dropdownOptions.map(o => o.value)).toStrictEqual([FDA_LEVELS.LEVEL_FDA3, FDA_LEVELS.LEVEL_FDA_NO]);
+      },
     );
   });
 
@@ -45,7 +40,7 @@ describe('Firebase Level Utils', () => {
       txLevel => {
         const options = getPropagatedLevelDropdownOptions(txLevel);
         expect(options.map(o => o.value)).toStrictEqual([TX_LEVELS.LEVEL_3B, TX_LEVELS.LEVEL_4, TX_LEVELS.LEVEL_NO]);
-      }
+      },
     );
 
     it('should return levels 4 and no when highest level is 4', () => {
@@ -58,7 +53,7 @@ describe('Firebase Level Utils', () => {
       txLevel => {
         const options = getPropagatedLevelDropdownOptions(txLevel);
         expect(options.length).toEqual(0);
-      }
+      },
     );
   });
 });

--- a/src/main/webapp/app/shared/util/firebase/firebase-level-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-level-utils.tsx
@@ -4,8 +4,6 @@ import {
   ALL_LEVELS,
   DIAGNOSTIC_LEVELS_ORDERING,
   FDA_LEVELS_ORDERING,
-  FDA_LEVEL_KEYS,
-  FDA_LEVEL_KEYS_MAPPING,
   PROGNOSTIC_LEVELS_ORDERING,
   THERAPEUTIC_LEVELS_ORDERING,
   THERAPEUTIC_RESISTANCE_LEVELS,
@@ -25,7 +23,7 @@ export enum LevelType {
   FDA,
 }
 
-export type LEVELS = ONCOKB_LEVELS | FDA_LEVEL_KEYS;
+export type LEVELS = ONCOKB_LEVELS | FDA_LEVELS;
 
 export type ONCOKB_LEVELS = TX_LEVELS | PX_LEVELS | DX_LEVELS;
 
@@ -68,11 +66,7 @@ export const getLevelDropdownOptions = (levels: LEVELS[]) => {
 };
 
 export const getLevelDropdownOption = (level: LEVELS): RealtimeDropdownOptions => {
-  let mappedFdaLevel = undefined;
-  if (level in FDA_LEVEL_KEYS) {
-    mappedFdaLevel = FDA_LEVEL_KEYS_MAPPING[level];
-  }
-  return { label: <LevelWithDescription level={level} />, value: mappedFdaLevel ? mappedFdaLevel : level };
+  return { label: <LevelWithDescription level={level} />, value: level };
 };
 
 export const getTxLevelDropdownOptions = () => {
@@ -86,22 +80,22 @@ export const getTxLevelDropdownOptions = () => {
 
 export type PropagatedDropdownLevels = {
   dropdownOptions: RealtimeDropdownOptions[];
-  defaultPropagation: TX_LEVELS | FDA_LEVEL_KEYS | '';
+  defaultPropagation: TX_LEVELS | FDA_LEVELS | '';
 };
 
 export const getFdaPropagationInfo = (txLevel: TX_LEVELS): PropagatedDropdownLevels => {
-  let propagationOptions: FDA_LEVEL_KEYS[] = [];
+  let propagationOptions: FDA_LEVELS[] = [];
   let defaultPropagation = '';
   if (txLevel === TX_LEVELS.LEVEL_1 || txLevel === TX_LEVELS.LEVEL_2 || txLevel === TX_LEVELS.LEVEL_R1) {
-    propagationOptions = [FDA_LEVEL_KEYS.LEVEL_FDA2, FDA_LEVEL_KEYS.LEVEL_FDA3, FDA_LEVEL_KEYS.LEVEL_FDA_NO];
-    defaultPropagation = FDA_LEVEL_KEYS.LEVEL_FDA2;
+    propagationOptions = [FDA_LEVELS.LEVEL_FDA2, FDA_LEVELS.LEVEL_FDA3, FDA_LEVELS.LEVEL_FDA_NO];
+    defaultPropagation = FDA_LEVELS.LEVEL_FDA2;
   } else {
-    propagationOptions = [FDA_LEVEL_KEYS.LEVEL_FDA3, FDA_LEVEL_KEYS.LEVEL_FDA_NO];
-    defaultPropagation = FDA_LEVEL_KEYS.LEVEL_FDA3;
+    propagationOptions = [FDA_LEVELS.LEVEL_FDA3, FDA_LEVELS.LEVEL_FDA_NO];
+    defaultPropagation = FDA_LEVELS.LEVEL_FDA3;
   }
   return {
     dropdownOptions: getLevelDropdownOptions(propagationOptions),
-    defaultPropagation: defaultPropagation as FDA_LEVEL_KEYS,
+    defaultPropagation: defaultPropagation as FDA_LEVELS,
   };
 };
 
@@ -113,13 +107,4 @@ export const getPropagatedLevelDropdownOptions = (txLevel: TX_LEVELS): RealtimeD
     propagationOptions = [TX_LEVELS.LEVEL_4, TX_LEVELS.LEVEL_NO];
   }
   return getLevelDropdownOptions(propagationOptions);
-};
-
-export const convertToFdaLevelKey = (fdaLevel: FDA_LEVELS) => {
-  const fdaLevelKeyMapping = Object.keys(FDA_LEVEL_KEYS_MAPPING) as FDA_LEVEL_KEYS[];
-  for (const k of fdaLevelKeyMapping) {
-    if (FDA_LEVEL_KEYS_MAPPING[k] === fdaLevel) {
-      return k;
-    }
-  }
 };


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb-pipeline/issues/416

Issue:
The legacy platform saves FDA level with prefix (`Fda2`), but in new platform we don't.