### PR TITLE
Add carrier to allele state options in genomic indicators table

### DIFF
--- a/src/main/resources/config/liquibase/data/allele_state.csv
+++ b/src/main/resources/config/liquibase/data/allele_state.csv
@@ -2,3 +2,4 @@ name
 Monoallelic
 Biallelic
 Mosaic
+Carrier

--- a/src/main/webapp/app/components/geneHistoryTooltip/gene-history-tooltip-utils.tsx
+++ b/src/main/webapp/app/components/geneHistoryTooltip/gene-history-tooltip-utils.tsx
@@ -90,6 +90,8 @@ export function formatLocation(location: string, drugList: IDrug[], objectField:
       return location + ', Biallelic';
     } else if (objectField === 'mosaic') {
       return location + ', Mosaic';
+    } else if (objectField === 'carrier') {
+      return location + ', Carrier';
     }
   } else if (lastSubstring.endsWith('Penetrance')) {
     if (objectField === 'penetrance') {

--- a/src/main/webapp/app/components/tabs/CurationHistoryTab.tsx
+++ b/src/main/webapp/app/components/tabs/CurationHistoryTab.tsx
@@ -1,5 +1,4 @@
 import { APP_HISTORY_FORMAT, APP_TIME_FORMAT, GET_ALL_DRUGS_PAGE_SIZE } from 'app/config/constants/constants';
-import { HistoryRecord } from 'app/shared/model/firebase/firebase.model';
 import DefaultTooltip from 'app/shared/tooltip/DefaultTooltip';
 import { componentInject } from 'app/shared/util/typed-inject';
 import { IRootStore } from 'app/stores';
@@ -8,7 +7,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { FaHistory } from 'react-icons/fa';
 import { TextFormat } from 'react-jhipster';
 import ReactSelect from 'react-select';
-import { Button, Input, Label, Row } from 'reactstrap';
+import { Button, Input, Label } from 'reactstrap';
 import constructTimeSeriesData, { formatLocation } from '../geneHistoryTooltip/gene-history-tooltip-utils';
 import { ExtraTimeSeriesEventData, RequiredTimeSeriesEventData } from '../timeSeries/TimeSeries';
 import './curation-history-tab.scss';
@@ -21,28 +20,8 @@ export interface ICurationHistoryTabProps extends StoreProps {
   historyData: FlattenedHistory[];
 }
 
-type HistoryTabData = {
-  record: HistoryRecord;
-  timeStamp: number;
-  admin: string;
-  location: string;
-  objectField?: string;
-};
-
 const CurationHistoryTab = observer(({ historyData, getUsers, users, historyTabStore, getDrugs }: ICurationHistoryTabProps) => {
   const [drugList, setDrugList] = useState<IDrug[]>([]);
-
-  function findObjectFieldsInRecord(record: HistoryRecord) {
-    const fields = ['description', 'oncogenic', 'effect', 'penetrance', 'inheritanceMechanism', 'monoallelic', 'biallelic', 'mosaic'];
-
-    const output: string[] = [];
-    for (const field of fields) {
-      if (record.new[field]) {
-        output.push(field);
-      }
-    }
-    return output;
-  }
 
   const parsedHistoryData = useMemo(() => {
     if (!historyData) {

--- a/src/main/webapp/app/config/constants/firebase.ts
+++ b/src/main/webapp/app/config/constants/firebase.ts
@@ -22,6 +22,7 @@ export enum ALLELE_STATE {
   MONOALLELIC = 'Monoallelic',
   BIALLELIC = 'Biallelic',
   MOSAIC = 'Mosaic',
+  CARRIER = 'Carrier',
 }
 
 export const GENE_TYPE_KEY: { [key in GENE_TYPE]: string } = {
@@ -306,6 +307,7 @@ export enum READABLE_FIELD {
   BIALLELIC = 'Biallelic',
   MONOALLELIC = 'Monoallelic',
   MOSAIC = 'Mosaic',
+  CARRIER = 'Carrier',
   DIAGNOSTIC = 'Diagnostic',
   PROGNOSTIC = 'Prognostic',
   DIAGNOSTIC_SUMMARY = 'Diagnostic Summary',
@@ -350,6 +352,7 @@ export const FIREBASE_KEY_TO_READABLE_FIELD: { [key: string]: READABLE_FIELD } =
   biallelic: READABLE_FIELD.BIALLELIC,
   monoallelic: READABLE_FIELD.MONOALLELIC,
   mosaic: READABLE_FIELD.MOSAIC,
+  carrier: READABLE_FIELD.CARRIER,
   oncogenic: READABLE_FIELD.ONCOGENIC,
   short: READABLE_FIELD.ADDITIONAL_INFORMATION,
   fdaLevel: READABLE_FIELD.FDA_LEVEL,

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -145,6 +145,9 @@ export class AlleleState {
   mosaic: ALLELE_STATE.MOSAIC | '' = '';
   mosaic_uuid = generateUuid();
   mosaic_review?: Review;
+  carrier: ALLELE_STATE.CARRIER | '' = '';
+  carrier_uuid = generateUuid();
+  carrier_review?: Review;
 }
 export class Gene {
   name = '';

--- a/src/main/webapp/app/shared/table/GenomicIndicatorsTable.tsx
+++ b/src/main/webapp/app/shared/table/GenomicIndicatorsTable.tsx
@@ -152,7 +152,7 @@ const GenomicIndicatorsTable = ({
                   <RealtimeCheckedInputGroup
                     disabled={genomicIndicator.name_review?.removed || false}
                     groupHeader={''}
-                    options={[ALLELE_STATE.MONOALLELIC, ALLELE_STATE.BIALLELIC, ALLELE_STATE.MOSAIC].map(label => {
+                    options={[ALLELE_STATE.MONOALLELIC, ALLELE_STATE.BIALLELIC, ALLELE_STATE.MOSAIC, ALLELE_STATE.CARRIER].map(label => {
                       return {
                         label,
                         firebasePath: `${genomicIndicatorPath}/allele_state/${label.toLowerCase()}`,


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb-pipeline/issues/448

Curation team is not sure if `Carrier` needs to be added to the Cancer Risk section, so that is option is skipped for now.