### PR TITLE
Explore new table with Excel-like filtering feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "@sentry/react": "^7.112.2",
     "@sentry/webpack-plugin": "^2.17.0",
     "@superwf/mobx-react-router": "^7.4.0",
+    "ag-grid-community": "^32.0.0",
+    "ag-grid-react": "^32.0.0",
     "availity-reactstrap-validation": "^2.7.1",
     "axios": "1.6.8",
     "bootstrap": "5.3.3",

--- a/src/main/webapp/app/shared/table/OncoKBGrid.tsx
+++ b/src/main/webapp/app/shared/table/OncoKBGrid.tsx
@@ -1,0 +1,29 @@
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/styles/ag-grid.css';
+import 'ag-grid-community/styles/ag-theme-quartz.css';
+import { GridOptions } from 'ag-grid-community';
+import React, { useMemo } from 'react';
+
+export interface IOncoKBGrid<T> extends GridOptions<T> {}
+
+export const OncoKBGrid = <T extends object>(props: IOncoKBGrid<T>) => {
+  const defaultColDef = useMemo(() => {
+    return {
+      filter: 'agGroupColumnFilter',
+    };
+  }, []);
+  return (
+    <div className={'ag-theme-quartz'}>
+      <AgGridReact
+        rowSelection="multiple"
+        defaultColDef={defaultColDef}
+        suppressRowClickSelection={true}
+        pagination={true}
+        paginationPageSize={10}
+        paginationPageSizeSelector={[10, 25, 50]}
+        domLayout="autoHeight"
+        {...props}
+      />
+    </div>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4454,6 +4454,26 @@ acorn@^8.1.0, acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.1, acorn@^8.8.2, acorn@^8.9
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
+ag-charts-types@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/ag-charts-types/-/ag-charts-types-10.0.0.tgz#241f148560815cd4a9f090a6462d4d761480d3d8"
+  integrity sha512-jjiwrzydERou4yp9WHiJeVK237B7BUP3/4j6tdycyHag266YVWa/BMNtTOThWJKGku+m+TC2qfaujLYixgcbrQ==
+
+ag-grid-community@32.0.0, ag-grid-community@^32.0.0:
+  version "32.0.0"
+  resolved "https://registry.yarnpkg.com/ag-grid-community/-/ag-grid-community-32.0.0.tgz#ba2807d20eed65599565cb9f1a49ecdeeb2de789"
+  integrity sha512-H0I19/+SXTP/uMeG58nlm/Fj1rMKlX6mnbMW+MrfJ+e0/aguOtrOG+UGOn8f3CTmSwjOIQquCmu3gK8hBMqgtQ==
+  dependencies:
+    ag-charts-types "10.0.0"
+
+ag-grid-react@^32.0.0:
+  version "32.0.0"
+  resolved "https://registry.yarnpkg.com/ag-grid-react/-/ag-grid-react-32.0.0.tgz#ac6debbc74eb0841073126ed198ae507072e8976"
+  integrity sha512-zr/fGeQn/Li/EPgmKF2PS4w5BZK5Q/KUeifVkqw8wNTYhJB3zp1NFFEu3CWcn+Q5WoYoTZGnY0N00UHM6TzhoQ==
+  dependencies:
+    ag-grid-community "32.0.0"
+    prop-types "^15.8.1"
+
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz"
@@ -17092,7 +17112,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17109,6 +17129,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.1.0:
   version "2.1.1"
@@ -17196,7 +17225,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -17223,6 +17252,13 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -19118,7 +19154,7 @@ workerpool@6.2.1:
   resolved "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -19131,6 +19167,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This is related to https://github.com/oncokb/oncokb/issues/3739

I was unable to use ag-grid for oncokb-public because some of the packages are not compatible. We can let the curation team try it out first on the curation platform. If we find this library to be better, then we can explore upgrading packages for oncokb-public.

Here is a demo: https://www.ag-grid.com/example/

### Changes
- Converted gene list table to ag grid

Comparison:
![image](https://github.com/oncokb/oncokb-transcript/assets/59149377/ff772909-2562-45d8-bc60-4dc3639aeb59)

The Excel style checkbox filters is only available in AG Grid Enterprise, but we can build our own sorting feature. Enterprise (paid version) will just help reduce development time.
![image](https://github.com/oncokb/oncokb-transcript/assets/59149377/c5584d4f-4f67-40db-b1a5-1550cbcb623d)


