### PR TITLE
Add Pathogenic Variants to Mutations list when adding genomic indicator

### DIFF
--- a/src/main/webapp/app/shared/util/firebase/firebase-path-utils.ts
+++ b/src/main/webapp/app/shared/util/firebase/firebase-path-utils.ts
@@ -3,10 +3,11 @@ import { FB_COLLECTION } from 'app/config/constants/firebase';
 type FirebaseGenePathDetails = {
   fullPath: string;
   hugoSymbol: string;
+  genePath: string;
   pathFromGene: string;
 };
 
-export const parseFirebaseGenePath = (path: string) => {
+export const parseFirebaseGenePath = (path: string): FirebaseGenePathDetails => {
   const pathParts = path.split('/').filter(part => part.length > 0);
   if (pathParts.length < 3) {
     return;
@@ -16,8 +17,9 @@ export const parseFirebaseGenePath = (path: string) => {
   return {
     fullPath: path,
     hugoSymbol,
+    genePath: `${pathParts[0]}/${pathParts[1]}`,
     pathFromGene,
-  } as FirebaseGenePathDetails;
+  };
 };
 
 export const buildFirebaseGenePath = (hugoSymbol: string, fieldKey: string) => {

--- a/src/main/webapp/app/stores/createStore.ts
+++ b/src/main/webapp/app/stores/createStore.ts
@@ -245,6 +245,7 @@ export function createStores(history: History): IRootStore {
   const firebaseGeneService = new FirebaseGeneService(
     firebaseRepository,
     rootStore.authStore,
+    firebaseMutationListStore,
     firebaseMutationConvertIconStore,
     firebaseMetaService,
     firebaseGeneReviewService,


### PR DESCRIPTION
The genomic indicator is automatically associated with Pathogenic Variants. We like to make sure it's included in the mutation list.

This fixes https://github.com/oncokb/oncokb-pipeline/issues/389