### PR TITLE
Fix cancer type change reverted check

### DIFF
--- a/src/main/webapp/app/service/firebase/firebase-gene-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-service.ts
@@ -290,12 +290,21 @@ export class FirebaseGeneService {
     tumor: Tumor,
     isGermline: boolean,
   ) => {
-    const cancerTypesReview = getUpdatedReview(tumor.cancerTypes_review, currentCancerTypes, tumor.cancerTypes, this.authStore.fullName);
+    const cancerTypesReview = getUpdatedReview(
+      tumor.cancerTypes_review,
+      currentCancerTypes,
+      tumor.cancerTypes,
+      this.authStore.fullName,
+      true,
+      true,
+    );
     const excludedCancerTypesReview = getUpdatedReview(
       tumor.excludedCancerTypes_review,
       currentExcludedCancerTypes,
       tumor.excludedCancerTypes,
       this.authStore.fullName,
+      true,
+      true,
     );
 
     tumor.cancerTypes_review = cancerTypesReview.updatedReview;

--- a/src/main/webapp/app/service/firebase/firebase-meta-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-meta-service.ts
@@ -89,10 +89,22 @@ export class FirebaseMetaService {
 
   getUpdateObject = (add: boolean, hugoSymbol: string, isGermline: boolean, uuid: string) => {
     const metaGenePath = getFirebaseMetaGenePath(isGermline, hugoSymbol);
-    return {
+    const uuidUpdateValue = add ? true : null;
+    const updateObject: { [key: string]: string | boolean | null } = {
       [`${metaGenePath}/lastModifiedBy`]: this.authStore.fullName,
       [`${metaGenePath}/lastModifiedAt`]: new Date().getTime().toString(),
-      [`${metaGenePath}/review/${uuid}`]: add ? true : null,
+      [`${metaGenePath}/review/${uuid}`]: uuidUpdateValue,
     };
+    if (uuid.includes(',')) {
+      // Cancer Type name review may contain only cancerTypes_uuid or BOTH cancerTypes_uuid and excludedCancerTypes_uuid.
+      // We want to remove all uuids in meta collection that contains either uuids.
+      uuid
+        .split(',')
+        .map(uuidPart => uuidPart.trim())
+        .forEach(uuidPart => {
+          updateObject[`${metaGenePath}/review/${uuidPart}`] = uuidUpdateValue;
+        });
+    }
+    return updateObject;
   };
 }

--- a/src/main/webapp/app/shared/modal/ModifyCancerTypeModal.tsx
+++ b/src/main/webapp/app/shared/modal/ModifyCancerTypeModal.tsx
@@ -23,9 +23,15 @@ export interface IModifyCancerTypeModalProps extends StoreProps {
 
 export function getCancerTypeFromCancerTypeSelectOption(cancerTypeSelectOption: CancerTypeSelectOption) {
   const cancerType = new CancerType();
-  cancerType.code = cancerTypeSelectOption.code;
-  cancerType.mainType = cancerTypeSelectOption.mainType;
-  cancerType.subtype = cancerTypeSelectOption.subtype;
+  if (!_.isNil(cancerTypeSelectOption.code)) {
+    cancerType.code = cancerTypeSelectOption.code;
+  }
+  if (!_.isNil(cancerTypeSelectOption.mainType)) {
+    cancerType.mainType = cancerTypeSelectOption.mainType;
+  }
+  if (!_.isNil(cancerTypeSelectOption.subtype)) {
+    cancerType.subtype = cancerTypeSelectOption.subtype;
+  }
   return cancerType;
 }
 
@@ -88,13 +94,13 @@ const ModifyCancerTypeModalContent = observer(
         if (!cancerType) {
           return accumulator;
         }
-
         const option: CancerTypeSelectOption = {
           label: getCancerTypeName(cancerType),
           value: cancerType.id,
           code: cancerType.code,
           mainType: cancerType.mainType,
           subtype: cancerType.subtype,
+          level: cancerType.level,
         };
         return [...accumulator, option];
       }, []);

--- a/src/main/webapp/app/shared/modal/modify-cancer-type-modal.store.ts
+++ b/src/main/webapp/app/shared/modal/modify-cancer-type-modal.store.ts
@@ -78,13 +78,13 @@ export class ModifyCancerTypeModalStore {
   setIncludedCancerTypes(cancerTypes: CancerTypeSelectOption[], allCancerTypes: Tumor[], cancerTypeToEditUuid?: string) {
     this.setIsErrorIncludedAndExcluded(cancerTypes, this.excludedCancerTypes);
     this.setIsErrorDuplicate(cancerTypes, this.excludedCancerTypes, allCancerTypes, cancerTypeToEditUuid);
-    this.includedCancerTypes = cancerTypes.map(removeCancerTypeCode);
+    this.includedCancerTypes = cancerTypes;
   }
 
   setExcludedCancerTypes(cancerTypes: CancerTypeSelectOption[], allCancerTypes: Tumor[], cancerTypeToEditUuid?: string) {
     this.setIsErrorIncludedAndExcluded(this.includedCancerTypes, cancerTypes);
     this.setIsErrorDuplicate(this.includedCancerTypes, cancerTypes, allCancerTypes, cancerTypeToEditUuid);
-    this.excludedCancerTypes = cancerTypes.map(removeCancerTypeCode);
+    this.excludedCancerTypes = cancerTypes;
   }
 
   setIsErrorFetchingICancerTypes(isError: boolean) {
@@ -109,13 +109,3 @@ export class ModifyCancerTypeModalStore {
     this.isRetryButtonClicked = false;
   }
 }
-
-// Once https://github.com/oncokb/oncokb-pipeline/issues/413 is fixed, we can remove this function.
-// Then we should complete this ticket: https://github.com/oncokb/oncokb-pipeline/issues/494 to backfill
-// all place where code == "" in firebase.
-const removeCancerTypeCode = (cancerTypeOption: CancerTypeSelectOption) => {
-  if (cancerTypeOption.level < 0) {
-    cancerTypeOption.code = null;
-  }
-  return cancerTypeOption;
-};

--- a/src/main/webapp/app/shared/modal/modify-cancer-type-modal.store.ts
+++ b/src/main/webapp/app/shared/modal/modify-cancer-type-modal.store.ts
@@ -78,13 +78,13 @@ export class ModifyCancerTypeModalStore {
   setIncludedCancerTypes(cancerTypes: CancerTypeSelectOption[], allCancerTypes: Tumor[], cancerTypeToEditUuid?: string) {
     this.setIsErrorIncludedAndExcluded(cancerTypes, this.excludedCancerTypes);
     this.setIsErrorDuplicate(cancerTypes, this.excludedCancerTypes, allCancerTypes, cancerTypeToEditUuid);
-    this.includedCancerTypes = cancerTypes;
+    this.includedCancerTypes = cancerTypes.map(removeCancerTypeCode);
   }
 
   setExcludedCancerTypes(cancerTypes: CancerTypeSelectOption[], allCancerTypes: Tumor[], cancerTypeToEditUuid?: string) {
     this.setIsErrorIncludedAndExcluded(this.includedCancerTypes, cancerTypes);
     this.setIsErrorDuplicate(this.includedCancerTypes, cancerTypes, allCancerTypes, cancerTypeToEditUuid);
-    this.excludedCancerTypes = cancerTypes;
+    this.excludedCancerTypes = cancerTypes.map(removeCancerTypeCode);
   }
 
   setIsErrorFetchingICancerTypes(isError: boolean) {
@@ -109,3 +109,13 @@ export class ModifyCancerTypeModalStore {
     this.isRetryButtonClicked = false;
   }
 }
+
+// Once https://github.com/oncokb/oncokb-pipeline/issues/413 is fixed, we can remove this function.
+// Then we should complete this ticket: https://github.com/oncokb/oncokb-pipeline/issues/494 to backfill
+// all place where code == "" in firebase.
+const removeCancerTypeCode = (cancerTypeOption: CancerTypeSelectOption) => {
+  if (cancerTypeOption.level < 0) {
+    cancerTypeOption.code = null;
+  }
+  return cancerTypeOption;
+};

--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -337,7 +337,7 @@ export class Implication {
 export class CancerType {
   code? = '';
   mainType? = '';
-  subtype?: string;
+  subtype? = '';
 }
 
 export class Drug {

--- a/src/main/webapp/app/shared/select/CancerTypeSelect.tsx
+++ b/src/main/webapp/app/shared/select/CancerTypeSelect.tsx
@@ -3,7 +3,7 @@ import { Props as SelectProps } from 'react-select';
 import _ from 'lodash';
 import { AsyncPaginate, reduceGroupedOptions } from 'react-select-async-paginate';
 import { defaultAdditional } from 'app/components/panels/CompanionDiagnosticDevicePanel';
-import { DEFAULT_SORT_PARAMETER, SearchOptionType } from 'app/config/constants/constants';
+import { SearchOptionType } from 'app/config/constants/constants';
 import { IRootStore } from 'app/stores/createStore';
 import { connect } from '../util/typed-inject';
 import { ICancerType } from '../model/cancer-type.model';
@@ -20,6 +20,7 @@ export type CancerTypeSelectOption = {
   code: string;
   mainType: string;
   subtype: string;
+  level: number;
   isDisabled?: boolean;
 };
 
@@ -44,6 +45,7 @@ const getAllCancerTypesOptions = (cancerTypeList: ICancerType[]) => {
             code: cancerType.code,
             mainType: cancerType.mainType,
             subtype: cancerType.subtype,
+            level: cancerType.level,
           };
         }),
     },
@@ -56,6 +58,7 @@ const getAllCancerTypesOptions = (cancerTypeList: ICancerType[]) => {
           code: cancerType.code,
           mainType: cancerType.mainType,
           subtype: cancerType.subtype,
+          level: cancerType.level,
         };
       }),
     },

--- a/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
@@ -868,10 +868,13 @@ export const getUpdatedReview = (
 
   // Update Review when value is reverted to original
   let isChangeReverted = false;
+  let shouldSetLastReviewed = true;
   if (!('lastReviewed' in oldReview)) {
-    const shouldSetLastReviewed = isCancerType && currentValue && !areCancerTypeArraysEqual(currentValue, newValue);
-    if (shouldSetLastReviewed) {
+    if (isCancerType) {
       // When just the cancer types ordering is changed, then a review should not be triggered.
+      shouldSetLastReviewed = currentValue && !areCancerTypeArraysEqual(currentValue, newValue);
+    }
+    if (shouldSetLastReviewed) {
       oldReview.lastReviewed = currentValue;
     }
     if (oldReview.lastReviewed === undefined) {

--- a/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
@@ -869,7 +869,11 @@ export const getUpdatedReview = (
   // Update Review when value is reverted to original
   let isChangeReverted = false;
   if (!('lastReviewed' in oldReview)) {
-    oldReview.lastReviewed = currentValue;
+    const shouldSetLastReviewed = isCancerType && currentValue && !areCancerTypeArraysEqual(currentValue, newValue);
+    if (shouldSetLastReviewed) {
+      // When just the cancer types ordering is changed, then a review should not be triggered.
+      oldReview.lastReviewed = currentValue;
+    }
     if (oldReview.lastReviewed === undefined) {
       oldReview = clearReview(oldReview);
     }

--- a/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
@@ -13,7 +13,7 @@ import {
 } from 'app/shared/model/firebase/firebase.model';
 import _ from 'lodash';
 import { generateUuid, getCancerTypesName, getCancerTypesNameWithExclusion } from '../utils';
-import { getMutationName, getTxName } from './firebase-utils';
+import { areCancerTypeArraysEqual, getMutationName, getTxName } from './firebase-utils';
 import { FB_COLLECTION, READABLE_FIELD, ReviewAction, ReviewLevelType } from 'app/config/constants/firebase';
 import { IDrug } from 'app/shared/model/drug.model';
 import { makeFirebaseKeysReadable } from './firebase-history-utils';
@@ -856,6 +856,7 @@ export const getUpdatedReview = (
   newValue: any,
   editorName: string,
   updateMetaData: boolean = true,
+  isCancerType: boolean = false,
 ) => {
   if (updateMetaData) {
     if (!oldReview) {
@@ -879,6 +880,8 @@ export const getUpdatedReview = (
     }
   } else if (_.isEqual(oldReview.lastReviewed, newValue)) {
     isChangeReverted = true;
+  } else if (isCancerType) {
+    isChangeReverted = areCancerTypeArraysEqual(oldReview.lastReviewed as CancerType[], newValue);
   }
 
   if (isChangeReverted && !oldReview.added) {

--- a/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
@@ -25,7 +25,7 @@ import _ from 'lodash';
 import React from 'react';
 import { TextFormat } from 'react-jhipster';
 import { replaceUrlParams } from '../url-utils';
-import { extractPositionFromSingleNucleotideAlteration, isUuid, parseAlterationName } from '../utils';
+import { extractPositionFromSingleNucleotideAlteration, getCancerTypeName, isUuid, parseAlterationName } from '../utils';
 import { isTxLevelPresent } from './firebase-level-utils';
 import { parseFirebaseGenePath } from './firebase-path-utils';
 import { hasReview } from './firebase-review-utils';
@@ -881,6 +881,12 @@ export function findNestedUuids(obj: any, uuids: string[] = []) {
 
 export function areCancerTypeArraysEqual(a: CancerType[], b: CancerType[]) {
   if (a.length !== b.length) return false;
+  a.sort((ct1, ct2) => {
+    return getCancerTypeName(ct1, false).localeCompare(getCancerTypeName(ct2, false));
+  });
+  b.sort((ct1, ct2) => {
+    return getCancerTypeName(ct1, false).localeCompare(getCancerTypeName(ct2, false));
+  });
   for (let i = 0; i < a.length; i++) {
     if (!areCancerTypePropertiesEqual(a[i].code, b[i].code)) return false;
     if (!areCancerTypePropertiesEqual(a[i].mainType, b[i].mainType)) return false;

--- a/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
@@ -5,6 +5,7 @@ import { IDrug } from 'app/shared/model/drug.model';
 import { CategoricalAlterationType } from 'app/shared/model/enumerations/categorical-alteration-type.model';
 import {
   Alteration,
+  CancerType,
   Comment,
   DX_LEVELS,
   FIREBASE_ONCOGENICITY,
@@ -876,4 +877,23 @@ export function findNestedUuids(obj: any, uuids: string[] = []) {
   }
 
   return uuids;
+}
+
+export function areCancerTypeArraysEqual(a: CancerType[], b: CancerType[]) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (!areCancerTypePropertiesEqual(a[i].code, b[i].code)) return false;
+    if (!areCancerTypePropertiesEqual(a[i].mainType, b[i].mainType)) return false;
+    if (!areCancerTypePropertiesEqual(a[i].subtype, b[i].subtype)) return false;
+  }
+  return true;
+}
+
+export function areCancerTypePropertiesEqual(a: string | undefined, b: string | undefined) {
+  if (a === b) return true;
+  return isStringEmpty(a) && isStringEmpty(b);
+}
+
+export function isStringEmpty(string: string | undefined | null) {
+  return string === '' || _.isNil(string);
 }


### PR DESCRIPTION
This fixes https://github.com/oncokb/oncokb-pipeline/issues/488

- [ ] Cleanup production firebase's meta collection

### Issues
1. There may be scenario where `excludedCancerTypes` is not defined yet but since `cancerTypes` was modified, only `cancerTypes_uuid` was added to meta to mark as review. Before that change has been reviewed, making a change to `excludedCancerTypes` will cause `cancerTypes_uuid, excludedCancerTypes_uuid` to be added to meta. After accepting/rejecting change, only `cancerTypes_uuid, excludedCancerTypes_uuid` was removed. The fix is to find all meta keys where either uuids are present and remove upon review.
2. Cancer types are not properly compared causing `isChangeReverted` to not be accurate.