### PR TITLE
Add async to getSessionGen

### DIFF
--- a/src/main/webapp/app/stores/authentication.store.ts
+++ b/src/main/webapp/app/stores/authentication.store.ts
@@ -102,7 +102,7 @@ export class AuthStore extends BaseStore {
     }
   }
 
-  *getSessionGen() {
+  async *getSessionGen() {
     if (this.isAuthenticated) {
       return this.account;
     }


### PR DESCRIPTION
@zhx828 @bprize15 
In `getSessionGen`, if the `axios.get('/api/account')` throws a 401 error, it never reaches the catch block. John and I found out that if you add `.catch` to axios.get(...) OR add async to generator function, the exception ends up being caught.

Let us know if you might know what the cause is. 