### PR TITLE
Fix realtime level dropdown inputs

### DIFF
--- a/src/main/webapp/app/service/firebase/firebase-gene-review-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-review-service.ts
@@ -59,7 +59,7 @@ export class FirebaseGeneReviewService {
     currentValue: any,
     updateValue: any,
     review: Review | null | undefined,
-    uuid: string | null,
+    uuid: string | null | undefined,
     updateMetaData: boolean = true,
     shouldSave: boolean = true,
   ) => {

--- a/src/main/webapp/app/shared/firebase/input/RealtimeLevelDropdownInput.tsx
+++ b/src/main/webapp/app/shared/firebase/input/RealtimeLevelDropdownInput.tsx
@@ -101,14 +101,14 @@ const RealtimeLevelDropdown = (props: IRealtimeLevelDropdown) => {
 
     if (levelOfEvidenceType === LevelOfEvidenceType.PROPAGATED_SOLID || levelOfEvidenceType === LevelOfEvidenceType.PROPAGATED_LIQUID) {
       // When highestLevel changes, the propagated levels should reset to no level
-      if (highestLevel && LOEReview) {
+      if (highestLevel) {
         updateReviewableContent?.(firebaseLevelPath, currentLOE, TX_LEVELS.LEVEL_NO, LOEReview, LOEUuid);
       }
     }
 
     if (levelOfEvidenceType === LevelOfEvidenceType.PROPAGATED_FDA) {
       // When highestLevel changes, the fda propagation should be reset to default
-      if (propagatedFdaLevel && LOEReview) {
+      if (propagatedFdaLevel) {
         updateReviewableContent?.(firebaseLevelPath, currentLOE, propagatedFdaLevel, LOEReview, LOEUuid);
       }
     }
@@ -118,9 +118,7 @@ const RealtimeLevelDropdown = (props: IRealtimeLevelDropdown) => {
     const oldLevel = currentLOE;
     const newLevel: LEVELS | '' = newValue?.value ?? TX_LEVELS.LEVEL_EMPTY;
 
-    if (LOEReview && LOEUuid) {
-      updateReviewableContent?.(firebaseLevelPath, oldLevel, newLevel, LOEReview, LOEUuid);
-    }
+    updateReviewableContent?.(firebaseLevelPath, oldLevel, newLevel, LOEReview, LOEUuid);
 
     props.onChange?.(newValue, actionMeta);
   };


### PR DESCRIPTION
https://github.com/oncokb/oncokb-pipeline/issues/509

The review object can be undefined if it is the first time a data point has been updated. There was a bug in code that checks if review is defined, which is not always the case.