### PR TITLE
Update github action release to support multiple branches

### DIFF
--- a/.github/workflows/after-branch-commit.yml
+++ b/.github/workflows/after-branch-commit.yml
@@ -1,16 +1,17 @@
-name: After master commit
+name: After branch commit
 
 on:
   push:
     branches:
       - master
+      - rc
 
 jobs:
   check-version-level-and-update:
-    if: github.repository == 'oncokb/oncokb-curation'
+    if: github.repository == 'oncokb/oncokb-transcript'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: 'Update Version Level'
@@ -39,27 +40,46 @@ jobs:
             git push
           fi
 
-
   update-pom:
     needs: [check-version-level-and-update]
-    if: github.repository == 'oncokb/oncokb-curation'
+    if: github.repository == 'oncokb/oncokb-transcript'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: 'Get Previous tag'
-        id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@master"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Extract branch name
+        id: extract_branch
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+
+      - name: Find previous release
+        id: find_release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = '${{ steps.extract_branch.outputs.branch }}';
+            console.log('Looking for a latest release that is based on branch: ${{ steps.extract_branch.outputs.branch }}');
+
+            const releases = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const release = releases.data.find(r => r.target_commitish === branch || r.target_commitish === `refs/heads/${branch}`);
+
+            if (release) {
+              core.setOutput('tag', release.tag_name);
+            } else {
+              core.setFailed("No tag available, fail the action.");
+            }
 
       - name: 'Get next semantic versions'
         id: semvers
         uses: "WyriHaximus/github-action-next-semvers@v1"
         with:
-          version: ${{ steps.previoustag.outputs.tag }}
+          version: ${{ steps.find_release.outputs.tag }}
 
       - name: 'Setup Java'
         uses: actions/setup-java@v1
@@ -67,14 +87,17 @@ jobs:
           java-version: 8
 
       - name: 'Get Current Version Level'
-        id: 'version-level'
+        id: version_level
         run: |
           VERSION_LEVEL=$(cat .version-level | tr "[:upper:]" "[:lower:]")
           echo "::set-output name=VERSION_LEVEL::$VERSION_LEVEL"
+
       - name: 'Update Pom'
+        if: ${{ success() }}
         env:
-          NEW_VERSION: ${{ steps.version-level.outputs.VERSION_LEVEL == 'minor' && steps.semvers.outputs.minor || steps.semvers.outputs.patch}}
+          NEW_VERSION: ${{ steps.version_level.outputs.VERSION_LEVEL == 'minor' && steps.semvers.outputs.minor || steps.semvers.outputs.patch}}
         run: |
+          echo "${NEW_VERSION}"
           git pull
           mvn --batch-mode versions:set -DnewVersion=${NEW_VERSION} -DgenerateBackupPoms=false
 

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -1,15 +1,11 @@
 name: Release Management
 
 on:
-  push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - master
   workflow_run:
     workflows:
-      - "After master commit"
+      - "After branch commit"
     branches:
-      - master
+      - rc
     types:
       - completed
 


### PR DESCRIPTION
- allow to update the pom version on both rc and master branch
- only generate release notes based on rc branch. The release drafter only generates a