### PR TITLE
Restore main type options in cancer select

### DIFF
--- a/src/main/webapp/app/shared/select/CancerTypeSelect.tsx
+++ b/src/main/webapp/app/shared/select/CancerTypeSelect.tsx
@@ -27,7 +27,7 @@ export type CancerTypeSelectOption =
   | undefined;
 
 const getAllMainTypes = (cancerTypeList: ICancerType[]) => {
-  return _.uniq(cancerTypeList.filter(cancerType => cancerType.level && cancerType.level <= 0)).sort();
+  return _.uniq(cancerTypeList.filter(cancerType => cancerType.level <= 0)).sort();
 };
 
 const getAllSubtypes = (cancerTypeList: ICancerType[]) => {
@@ -38,7 +38,7 @@ const getAllCancerTypesOptions = (cancerTypeList: ICancerType[]) => {
   return [
     {
       label: 'Cancer Type',
-      options: _.uniq(getAllMainTypes(cancerTypeList).filter(cancerType => cancerType.mainType && !cancerType.mainType.endsWith('NOS')))
+      options: _.uniq(getAllMainTypes(cancerTypeList).filter(cancerType => !cancerType.mainType.endsWith('NOS')))
         .sort()
         .map((cancerType): CancerTypeSelectOption => {
           return {


### PR DESCRIPTION
fixes https://github.com/oncokb/oncokb-pipeline/issues/514

Reverted some checks in this PR: https://github.com/oncokb/oncokb-transcript/pull/374/files#diff-a91f33c921fa62dc9aff971740373a2300bdf1de7fb0f893ddb8b6076ce37cb4

The issue was that main type tumors have level=0. Since `0` is a falsey value, it caused a bug.