### PR TITLE
Fix excluded ct review

### DIFF
--- a/src/main/webapp/app/service/firebase/firebase-gene-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-service.ts
@@ -320,6 +320,12 @@ export class FirebaseGeneService {
 
     const { hugoSymbol } = parseFirebaseGenePath(tumorPath) ?? {};
 
+    // Not every tumor name may have excluded tumors. We add initialUpdate flag in this case
+    // so that review mode can pick up.
+    if (_.isNil(currentExcludedCancerTypes) && tumor.excludedCancerTypes_review) {
+      tumor.excludedCancerTypes_review.initialUpdate = true;
+    }
+
     return this.firebaseRepository.update(tumorPath, tumor).then(() => {
       if (cancerTypesReview.isChangeReverted) {
         this.firebaseRepository.delete(`${tumorPath}/cancerTypes_review/lastReviewed`);

--- a/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
@@ -651,11 +651,13 @@ export const buildCancerTypeNameReview = (
     newState = tumor;
   } else if (cancerTypesReview?.removed) {
     oldState = tumor;
-  } else if (cancerTypesReview?.lastReviewed || excludedCTReview?.lastReviewed) {
+  } else if (cancerTypesReview?.lastReviewed || excludedCTReview?.lastReviewed || excludedCTReview?.initialUpdate) {
     nameUpdated = true;
     oldState = oldTumorName = getCancerTypesNameWithExclusion(
-      (cancerTypesReview?.lastReviewed as CancerType[]) || [],
-      (excludedCTReview?.lastReviewed as CancerType[]) || [],
+      (cancerTypesReview?.lastReviewed as CancerType[] | undefined) || tumor.cancerTypes,
+      excludedCTReview?.initialUpdate
+        ? []
+        : (excludedCTReview?.lastReviewed as CancerType[] | undefined) || tumor.excludedCancerTypes || [],
       true,
     );
     newState = newTumorName;


### PR DESCRIPTION
https://github.com/oncokb/oncokb-pipeline/issues/512

Since not all tumor may have excluded tumors, the `excludedCancerTypes` field will not exist. When exclusion get added via name change, the `lastReviewed` is empty array, which Firebase simply does not save. Therefore, we should use `initialUpdate` flag in review object to denote that the previous excluded tumor array was empty.