### PR TITLE
Remove uuid from meta when newly created tumor has been deleted

### DIFF
--- a/src/main/webapp/app/service/firebase/firebase-meta-service.spec.ts
+++ b/src/main/webapp/app/service/firebase/firebase-meta-service.spec.ts
@@ -1,0 +1,60 @@
+import { FirebaseRepository } from 'app/stores/firebase/firebase-repository';
+import { AuthStore } from 'app/stores';
+import { FirebaseMetaService } from './firebase-meta-service';
+import { mock, mockReset } from 'jest-mock-extended';
+import { getTumorNameUuid } from 'app/shared/util/firebase/firebase-review-utils';
+import _ from 'lodash';
+import { generateUuid } from 'app/shared/util/utils';
+
+describe('Firebase Meta Service', () => {
+  const DEFAULT_DATE = new Date('2023-01-01');
+  const DEFAULT_UUID = generateUuid();
+  const mockFirebaseRepository = mock<FirebaseRepository>();
+  const mockAuthStore = mock<AuthStore>();
+  let firebaseMetaService: FirebaseMetaService;
+
+  beforeEach(() => {
+    mockReset(mockFirebaseRepository);
+    mockReset(mockAuthStore);
+    firebaseMetaService = new FirebaseMetaService(mockFirebaseRepository, mockAuthStore);
+    jest.useFakeTimers().setSystemTime(DEFAULT_DATE);
+  });
+
+  describe('updateGeneReviewUuid', () => {
+    it('should update meta collection with uuid', async () => {
+      await firebaseMetaService.updateGeneReviewUuid('BRAF', DEFAULT_UUID, true, false);
+      expect(mockFirebaseRepository.update).toHaveBeenCalledWith('/', {
+        [`Meta/BRAF/review/${DEFAULT_UUID}`]: true,
+      });
+    });
+
+    it('should update meta collection with comma seperated uuids', async () => {
+      const cancerTypesUuid = generateUuid();
+      const excludedCancerTypesUuid = generateUuid();
+      await firebaseMetaService.updateGeneReviewUuid('BRAF', getTumorNameUuid(cancerTypesUuid, excludedCancerTypesUuid), true, false);
+      expect(mockFirebaseRepository.update).toHaveBeenCalledWith('/', {
+        [`Meta/BRAF/review/${cancerTypesUuid}, ${excludedCancerTypesUuid}`]: true,
+      });
+    });
+
+    it('should remove uuid from meta collection', async () => {
+      await firebaseMetaService.updateGeneReviewUuid('BRAF', DEFAULT_UUID, false, false);
+      expect(mockFirebaseRepository.update).toHaveBeenCalledWith('/', {
+        [`Meta/BRAF/review/${DEFAULT_UUID}`]: null,
+      });
+    });
+
+    it('should remove all uuids in comma seperated list from meta collection', async () => {
+      const cancerTypesUuid = generateUuid();
+      const excludedCancerTypesUuid = generateUuid();
+      await firebaseMetaService.updateGeneReviewUuid('BRAF', getTumorNameUuid(cancerTypesUuid, excludedCancerTypesUuid), false, false);
+      // The uuid of a tumor name change consists of two uuids that are comma seperated. They should
+      // should be cleared individually and together.
+      expect(mockFirebaseRepository.update).toHaveBeenCalledWith('/', {
+        [`Meta/BRAF/review/${cancerTypesUuid}, ${excludedCancerTypesUuid}`]: null,
+        [`Meta/BRAF/review/${cancerTypesUuid}`]: null,
+        [`Meta/BRAF/review/${excludedCancerTypesUuid}`]: null,
+      });
+    });
+  });
+});

--- a/src/main/webapp/app/service/firebase/firebase-meta-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-meta-service.ts
@@ -1,4 +1,4 @@
-import { getFirebaseMetaGenePath, getFirebaseMetaGeneReviewPath, getFirebasePath } from 'app/shared/util/firebase/firebase-utils';
+import { getFirebaseMetaGenePath, getFirebasePath } from 'app/shared/util/firebase/firebase-utils';
 import AuthStore from '../../stores/authentication.store';
 import { FirebaseRepository } from '../../stores/firebase/firebase-repository';
 import { Meta } from 'app/shared/model/firebase/firebase.model';
@@ -38,10 +38,12 @@ export class FirebaseMetaService {
     const updateObject = {
       [`${metaGenePath}/review/${uuid}`]: uuidUpdateValue,
     };
-    const uuidParts = this.getUuidParts(uuid);
-    uuidParts.forEach(uuidPart => {
-      updateObject[`${metaGenePath}/review/${uuidPart}`] = uuidUpdateValue;
-    });
+    if (!add) {
+      const uuidParts = this.getUuidParts(uuid);
+      uuidParts.forEach(uuidPart => {
+        updateObject[`${metaGenePath}/review/${uuidPart}`] = uuidUpdateValue;
+      });
+    }
     return this.firebaseRepository.update('/', updateObject);
   };
 
@@ -101,20 +103,22 @@ export class FirebaseMetaService {
       [`${metaGenePath}/lastModifiedAt`]: new Date().getTime().toString(),
       [`${metaGenePath}/review/${uuid}`]: uuidUpdateValue,
     };
-    const uuidParts = this.getUuidParts(uuid);
-    uuidParts.forEach(uuidPart => {
-      updateObject[`${metaGenePath}/review/${uuidPart}`] = uuidUpdateValue;
-    });
+    if (!add) {
+      const uuidParts = this.getUuidParts(uuid);
+      uuidParts.forEach(uuidPart => {
+        updateObject[`${metaGenePath}/review/${uuidPart}`] = uuidUpdateValue;
+      });
+    }
 
     return updateObject;
   };
 
   private getUuidParts = (uuid: string) => {
-    const parts: string[] = [];
+    let parts: string[] = [];
     if (uuid.includes(',')) {
       // Cancer Type name review may contain only cancerTypes_uuid or BOTH cancerTypes_uuid and excludedCancerTypes_uuid.
       // We want to remove all uuids in meta collection that contains either uuids.
-      parts.concat(uuid.split(',').map(uuidPart => uuidPart.trim()));
+      parts = parts.concat(uuid.split(',').map(uuidPart => uuidPart.trim()));
     }
     return parts;
   };

--- a/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-review-utils.tsx
@@ -956,3 +956,7 @@ export const showAsFirebaseTextArea = (hugoSymbol: string, valuePath: string, is
     genePath.endsWith('/prognosticSummary')
   );
 };
+
+export const getTumorNameUuid = (cancerTypesUuid: string, excludedCancerTypesUuid: string) => {
+  return `${cancerTypesUuid}, ${excludedCancerTypesUuid}`;
+};


### PR DESCRIPTION
fixes https://github.com/oncokb/oncokb-pipeline/issues/511

Was able to reproduce bug when:
Create a new tumor and delete it before review, the uuid is not cleared from meta collection.