### PR TITLE
Minor updates

### DIFF
--- a/src/main/webapp/app/components/tabs/CurationToolsTab.tsx
+++ b/src/main/webapp/app/components/tabs/CurationToolsTab.tsx
@@ -14,6 +14,7 @@ import { onValue, ref } from 'firebase/database';
 import { FB_COLLECTION } from 'app/config/constants/firebase';
 import SaveGeneButton from 'app/shared/button/SaveGeneButton';
 import { Unsubscribe } from 'firebase/database';
+import { geneIsReleased } from 'app/shared/util/entity-utils/gene-entity-utils';
 
 export type ReleaseGeneTestData = {
   passed: boolean;
@@ -120,7 +121,7 @@ export function CurationToolsTab({
 
   useEffect(() => {
     const geneData = geneEntities?.find(entity => entity.hugoSymbol === geneName);
-    setIsReleased(geneData?.flags?.some(flag => isReleasedFlag(flag)) || false);
+    setIsReleased(geneData === undefined ? false : geneIsReleased(geneData));
     geneToUpdate.current = geneData;
   }, [geneEntities, geneName]);
 

--- a/src/main/webapp/app/entities/drug/drug-update.tsx
+++ b/src/main/webapp/app/entities/drug/drug-update.tsx
@@ -140,7 +140,7 @@ export const DrugUpdate = (props: IDrugUpdateProps) => {
                 {flags
                   ? flags.map(otherEntity => (
                       <option value={otherEntity.id} key={otherEntity.id}>
-                        {otherEntity.id}
+                        Type: {otherEntity.type}, Flag: {otherEntity.name}
                       </option>
                     ))
                   : null}

--- a/src/main/webapp/app/service/firebase/firebase-gene-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-service.ts
@@ -33,10 +33,13 @@ import { getErrorMessage } from 'app/oncokb-commons/components/alert/ErrorAlertU
 import { FirebaseDataStore } from 'app/stores/firebase/firebase-data.store';
 import { getTumorNameUuid, getUpdatedReview } from 'app/shared/util/firebase/firebase-review-utils';
 import { SentryError } from 'app/config/sentry-error';
-import { GERMLINE_PATH } from 'app/config/constants/constants';
+import { GERMLINE_PATH, GET_ALL_DRUGS_PAGE_SIZE } from 'app/config/constants/constants';
 import _ from 'lodash';
 import { getDriveAnnotations } from 'app/shared/util/core-drive-annotation-submission/core-drive-annotation-submission';
 import { DriveAnnotationApi } from 'app/shared/api/manual/drive-annotation-api';
+import GeneStore from 'app/entities/gene/gene.store';
+import { geneIsReleased } from 'app/shared/util/entity-utils/gene-entity-utils';
+import DrugStore from 'app/entities/drug/drug.store';
 
 export type AllLevelSummary = {
   [mutationUuid: string]: {
@@ -71,6 +74,8 @@ export type MutationLevelSummary = {
 export class FirebaseGeneService {
   firebaseRepository: FirebaseRepository;
   authStore: AuthStore;
+  geneStore: GeneStore;
+  drugStore: DrugStore;
   firebaseMutationListStore: FirebaseDataStore<Mutation[]>;
   firebaseMutationConvertIconStore: FirebaseDataStore<Mutation[]>;
   firebaseMetaService: FirebaseMetaService;
@@ -80,6 +85,8 @@ export class FirebaseGeneService {
   constructor(
     firebaseRepository: FirebaseRepository,
     authStore: AuthStore,
+    geneStore: GeneStore,
+    drugStore: DrugStore,
     firebaseMutationListStore: FirebaseDataStore<Mutation[]>,
     firebaseMutationConvertIconStore: FirebaseDataStore<Mutation[]>,
     firebaseMetaService: FirebaseMetaService,
@@ -88,6 +95,8 @@ export class FirebaseGeneService {
   ) {
     this.firebaseRepository = firebaseRepository;
     this.authStore = authStore;
+    this.geneStore = geneStore;
+    this.drugStore = drugStore;
     this.firebaseMutationListStore = firebaseMutationListStore;
     this.firebaseMutationConvertIconStore = firebaseMutationConvertIconStore;
     this.firebaseMetaService = firebaseMetaService;
@@ -565,33 +574,60 @@ export class FirebaseGeneService {
     await this.firebaseRepository.update(path, value);
   };
 
-  saveAllGenes = async (isGermlineProp: boolean, drugLookup: DrugCollection) => {
+  getDrugs = async () => {
+    const drugs = await this.drugStore.getEntities({ page: 0, size: GET_ALL_DRUGS_PAGE_SIZE, sort: ['id,asc'] });
+    return (
+      drugs.data.reduce((acc, next) => {
+        acc[next.uuid] = {
+          uuid: next.uuid,
+          description: '',
+          priority: 0,
+          synonyms: next.nciThesaurus?.synonyms?.map(synonym => synonym.name) || [],
+          ncitCode: next.nciThesaurus?.code || '',
+          ncitName: next.nciThesaurus?.displayName || '',
+          drugName: next.name,
+        };
+        return acc;
+      }, {} as DrugCollection) || {}
+    );
+  };
+
+  saveAllGenes = async (isGermlineProp: boolean) => {
+    const drugLookup = await this.getDrugs();
     const geneLookup = ((await this.firebaseRepository.get(getFirebaseGenePath(isGermlineProp))).val() as Record<string, Gene>) ?? {};
     const vusLookup =
       ((await this.firebaseRepository.get(getFirebaseVusPath(isGermlineProp))).val() as Record<string, Record<string, Vus>>) ?? {};
+    let count = 0;
     for (const [hugoSymbol, gene] of Object.entries(geneLookup)) {
+      count++;
+      console.log(`${count} - Saving ${hugoSymbol}...`);
       const nullableVus: Record<string, Vus> | null = vusLookup[hugoSymbol];
-      const args: Parameters<typeof getDriveAnnotations>[1] = {
-        gene,
-        vus: nullableVus == null ? undefined : Object.values(nullableVus),
-        releaseGene: true,
-      };
-      const driveAnnotation = getDriveAnnotations(drugLookup, args);
-      await this.driveAnnotationApi.submitDriveAnnotations(driveAnnotation);
+      await this.saveGeneWithData(isGermlineProp, hugoSymbol, drugLookup, gene, nullableVus);
+      console.log('\tDone Saving.');
     }
   };
 
   saveGene = async (isGermlineProp: boolean, hugoSymbolProp: string) => {
-    const drugLookup = (await this.firebaseRepository.get(FB_COLLECTION.DRUGS)).val() as Record<string, Drug>;
+    const drugLookup = await this.getDrugs();
     const nullableGene = (await this.firebaseRepository.get(getFirebaseGenePath(isGermlineProp, hugoSymbolProp))).val() as Gene | null;
     const nullableVus = (await this.firebaseRepository.get(getFirebaseVusPath(isGermlineProp, hugoSymbolProp))).val() as Record<
       string,
       Vus
     > | null;
+    await this.saveGeneWithData(isGermlineProp, hugoSymbolProp, drugLookup, nullableGene, nullableVus);
+  };
+  saveGeneWithData = async (
+    isGermlineProp: boolean,
+    hugoSymbolProp: string,
+    drugLookup: DrugCollection,
+    nullableGene: Gene | null,
+    nullableVus: Record<string, Vus> | null,
+  ) => {
+    const searchResponse = await this.geneStore.searchEntities({ query: hugoSymbolProp, exact: true });
     const args: Parameters<typeof getDriveAnnotations>[1] = {
       gene: nullableGene == null ? undefined : nullableGene,
       vus: nullableVus == null ? undefined : Object.values(nullableVus),
-      releaseGene: true,
+      releaseGene: searchResponse.data.some(gene => geneIsReleased(gene)),
     };
     const driveAnnotation = getDriveAnnotations(drugLookup, args);
     await this.driveAnnotationApi.submitDriveAnnotations(driveAnnotation);

--- a/src/main/webapp/app/service/firebase/firebase-gene-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-service.ts
@@ -574,6 +574,7 @@ export class FirebaseGeneService {
       const args: Parameters<typeof getDriveAnnotations>[1] = {
         gene,
         vus: nullableVus == null ? undefined : Object.values(nullableVus),
+        releaseGene: true,
       };
       const driveAnnotation = getDriveAnnotations(drugLookup, args);
       await this.driveAnnotationApi.submitDriveAnnotations(driveAnnotation);
@@ -590,6 +591,7 @@ export class FirebaseGeneService {
     const args: Parameters<typeof getDriveAnnotations>[1] = {
       gene: nullableGene == null ? undefined : nullableGene,
       vus: nullableVus == null ? undefined : Object.values(nullableVus),
+      releaseGene: true,
     };
     const driveAnnotation = getDriveAnnotations(drugLookup, args);
     await this.driveAnnotationApi.submitDriveAnnotations(driveAnnotation);

--- a/src/main/webapp/app/shared/api/clients.ts
+++ b/src/main/webapp/app/shared/api/clients.ts
@@ -14,6 +14,7 @@ import {
 import { DriveAnnotationApi } from './manual/drive-annotation-api';
 import { EvidenceApi } from './manual/evidence-api';
 import { GeneTypeApi } from './manual/gene-type-api';
+import { GeneApi } from 'app/shared/api/manual/gene-api';
 
 export const fdaSubmissionClient = new FdaSubmissionResourceApi(undefined, '', axiosInstance);
 export const geneClient = new GeneResourceApi(undefined, '', axiosInstance);
@@ -26,6 +27,8 @@ export const associationClient = new AssociationResourceApi(undefined, '', axios
 export const cancerTypeClient = new CancerTypeResourceApi(undefined, '', axiosInstance);
 export const articleClient = new ArticleResourceApi(undefined, '', axiosInstance);
 
+// The following are oncokb-core clients
 export const evidenceClient = new EvidenceApi(undefined, '', axiosInstance);
 export const geneTypeClient = new GeneTypeApi(undefined, '', axiosInstance);
 export const driveAnnotationClient = new DriveAnnotationApi(undefined, '', axiosInstance);
+export const geneLegacyApi = new GeneApi(undefined, '', axiosInstance);

--- a/src/main/webapp/app/shared/api/manual/drive-annotation-api.ts
+++ b/src/main/webapp/app/shared/api/manual/drive-annotation-api.ts
@@ -33,7 +33,11 @@ export const DriveAnnotationAxiosParamCreator = function (configuration?: Config
       localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
       const bodyFormData = new URLSearchParams();
       for (const [key, value] of Object.entries(driveAnnotation)) {
-        bodyFormData.append(key, value ?? '');
+        if (typeof value === 'boolean') {
+          bodyFormData.append(key, `${value}`);
+        } else {
+          bodyFormData.append(key, value ?? '');
+        }
       }
       localVarRequestOptions.data = bodyFormData;
 

--- a/src/main/webapp/app/shared/api/manual/gene-api.ts
+++ b/src/main/webapp/app/shared/api/manual/gene-api.ts
@@ -1,4 +1,4 @@
-import { createGeneTypePayload } from 'app/shared/util/core-gene-type-submission/core-gene-type-submission';
+import { createGeneTypePayload, removeGenePayload } from 'app/shared/util/core-gene-type-submission/core-gene-type-submission';
 import { BASE_PATH, BaseAPI, RequestArgs } from '../generated/core/base';
 import globalAxios, { AxiosPromise, AxiosInstance, AxiosRequestConfig } from 'axios';
 import { Configuration } from '../generated/core';
@@ -35,6 +35,34 @@ export const GeneAxiosParamCreator = function (configuration?: Configuration) {
         options: localVarRequestOptions,
       };
     },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async removeGene(gene: ReturnType<typeof removeGenePayload>, options: AxiosRequestConfig = {}): Promise<RequestArgs> {
+      // verify required parameter 'requestBody' is not null or undefined
+      assertParamExists('removeGeneFromCore', 'gene', gene);
+
+      const localVarPath = `/legacy-api/genes/remove/${gene.hugoSymbol}`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions: { headers: any } | undefined = undefined;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      localVarHeaderParameter['Content-Type'] = 'application/x-www-form-urlencoded';
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
   };
 };
 
@@ -48,6 +76,13 @@ export const GeneApiFp = function (configuration?: Configuration) {
       const localVarAxiosArgs = await localVarAxiosParamCreator.submitGenes(genes, options);
       return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
     },
+    async removeGene(
+      gene: ReturnType<typeof removeGenePayload>,
+      options: AxiosRequestConfig = {},
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.removeGene(gene, options);
+      return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+    },
   };
 };
 
@@ -55,6 +90,12 @@ export class GeneApi extends BaseAPI {
   public submitGenes(genes: ReturnType<typeof createGeneTypePayload>, options?: AxiosRequestConfig) {
     return GeneApiFp(this.configuration)
       .submitGenes(genes, options)
+      .then(request => request(this.axios, this.basePath));
+  }
+
+  public removeGene(gene: ReturnType<typeof removeGenePayload>, options?: AxiosRequestConfig) {
+    return GeneApiFp(this.configuration)
+      .removeGene(gene, options)
       .then(request => request(this.axios, this.basePath));
   }
 }

--- a/src/main/webapp/app/shared/button/SaveGeneButton.tsx
+++ b/src/main/webapp/app/shared/button/SaveGeneButton.tsx
@@ -12,15 +12,14 @@ type ISaveGeneButtonProps = StoreProps & {
 } & ButtonProps &
   Omit<React.HTMLAttributes<HTMLButtonElement>, 'onClick' | 'disabled'>;
 
-function SaveGeneButton({ hugoSymbol, firebaseGeneService, drugList, ...buttonProps }: ISaveGeneButtonProps) {
+function SaveGeneButton({ hugoSymbol, firebaseGeneService, ...buttonProps }: ISaveGeneButtonProps) {
   const [isSavePending, setIsSavePending] = useState(false);
-  const drugListRef = useDrugListRef(drugList);
   const onClickHandler = useCallback(async () => {
     setIsSavePending(true);
     try {
       const isGermline = false;
       if (hugoSymbol === undefined) {
-        await firebaseGeneService?.saveAllGenes(isGermline, drugListRef);
+        await firebaseGeneService?.saveAllGenes(isGermline);
         notifySuccess('All genes saved!');
       } else {
         await firebaseGeneService?.saveGene(isGermline, hugoSymbol);

--- a/src/main/webapp/app/shared/util/core-drive-annotation-submission/core-drive-annotation-submission.ts
+++ b/src/main/webapp/app/shared/util/core-drive-annotation-submission/core-drive-annotation-submission.ts
@@ -129,17 +129,20 @@ function getDrugsByUuids(keys: string[][], drugList: DrugCollection): Drug[][] {
   });
 }
 
-export type DriveAnnotation = { gene: string | undefined; vus: string | undefined };
+export type DriveAnnotation = { gene: string | undefined; vus: string | undefined; releaseGene: boolean };
 export function getDriveAnnotations(
   drugList: DrugCollection,
-  { gene, vus }: { gene: Gene | undefined; vus: Vus[] | undefined },
+  { gene, vus, releaseGene }: { gene: Gene | undefined; vus: Vus[] | undefined; releaseGene: boolean },
 ): DriveAnnotation {
-  const params: DriveAnnotation = { gene: undefined, vus: undefined };
+  const params: DriveAnnotation = { gene: undefined, vus: undefined, releaseGene: false };
   if (gene) {
     params.gene = JSON.stringify(getGeneData(gene, true, drugList));
   }
   if (vus) {
     params.vus = JSON.stringify(getVUSData(vus));
+  }
+  if (releaseGene) {
+    params.releaseGene = releaseGene;
   }
   return params;
 }

--- a/src/main/webapp/app/shared/util/core-drive-annotation-submission/core-drive-annotation-submission.ts
+++ b/src/main/webapp/app/shared/util/core-drive-annotation-submission/core-drive-annotation-submission.ts
@@ -124,6 +124,9 @@ function therapyStrToArr(key: string) {
 function getDrugsByUuids(keys: string[][], drugList: DrugCollection): Drug[][] {
   return keys.map(function (element) {
     return element.map(function (key) {
+      if (!drugList[key]) {
+        throw new Error(`Cannot find drug for ${key}`);
+      }
       return drugList[key];
     });
   });

--- a/src/main/webapp/app/shared/util/core-evidence-submission/core-evidence-submission.ts
+++ b/src/main/webapp/app/shared/util/core-evidence-submission/core-evidence-submission.ts
@@ -65,9 +65,9 @@ export function pathToGetEvidenceArgs({
     type = EvidenceEvidenceTypeEnum.GeneBackground;
   } else if (/^mutations\/\d+\/mutation_effect\/(effect|description)/.test(valuePath)) {
     type = EvidenceEvidenceTypeEnum.MutationEffect;
-  } else if (/^mutations\/\d+\/tumors\/\d+\/prognostic\/level/.test(valuePath)) {
+  } else if (/^mutations\/\d+\/tumors\/\d+\/prognostic\/.*/.test(valuePath)) {
     type = EvidenceEvidenceTypeEnum.PrognosticImplication;
-  } else if (/^mutations\/\d+\/tumors\/\d+\/diagnostic\/level/.test(valuePath)) {
+  } else if (/^mutations\/\d+\/tumors\/\d+\/diagnostic\/.*/.test(valuePath)) {
     type = EvidenceEvidenceTypeEnum.DiagnosticImplication;
   } else if (/^mutations\/\d+\/mutation_effect\/oncogenic/.test(valuePath)) {
     type = EvidenceEvidenceTypeEnum.Oncogenic;

--- a/src/main/webapp/app/shared/util/core-gene-type-submission/core-gene-type-submission.ts
+++ b/src/main/webapp/app/shared/util/core-gene-type-submission/core-gene-type-submission.ts
@@ -10,6 +10,11 @@ export function createGeneTypePayload(
     tsg: gene.type.tsg ? true : false,
   };
 }
+export function removeGenePayload(gene: Pick<Gene, 'name'>): Required<Pick<GenePayload, 'hugoSymbol'>> {
+  return {
+    hugoSymbol: gene.name,
+  };
+}
 
 export function isGeneTypeChange(path: string): boolean {
   return path.startsWith('type');

--- a/src/main/webapp/app/shared/util/entity-utils/gene-entity-utils.ts
+++ b/src/main/webapp/app/shared/util/entity-utils/gene-entity-utils.ts
@@ -1,0 +1,6 @@
+import { IFlag } from 'app/shared/model/flag.model';
+import { IGene } from 'app/shared/model/gene.model';
+
+export function geneIsReleased(gene: IGene): boolean {
+  return (gene.flags || []).some(flag => flag.type === 'GENE_PANEL' && flag.flag === 'ONCOKB');
+}

--- a/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
@@ -1,5 +1,5 @@
 import { APP_EXPANDED_DATETIME_FORMAT, CURRENT_REVIEWER } from 'app/config/constants/constants';
-import { FB_COLLECTION_PATH } from 'app/config/constants/firebase';
+import { FB_COLLECTION, FB_COLLECTION_PATH } from 'app/config/constants/firebase';
 import { NestLevelType, RemovableNestLevel } from 'app/pages/curation/collapsible/NestLevel';
 import { IDrug } from 'app/shared/model/drug.model';
 import { CategoricalAlterationType } from 'app/shared/model/enumerations/categorical-alteration-type.model';
@@ -16,9 +16,9 @@ import {
   PX_LEVELS,
   Review,
   TI,
-  TX_LEVELS,
   Treatment,
   Tumor,
+  TX_LEVELS,
   VusObjList,
 } from 'app/shared/model/firebase/firebase.model';
 import _ from 'lodash';
@@ -126,11 +126,11 @@ export const getFirebasePath = (type: keyof typeof FB_COLLECTION_PATH, ...params
 };
 
 export const getFirebaseGenePath = (isGermline: boolean | undefined, hugoSymbol?: string) => {
-  const basePath = isGermline ? 'GERMLINE_GENE' : 'GENE';
   if (hugoSymbol !== undefined) {
+    const basePath = isGermline ? 'GERMLINE_GENE' : 'GENE';
     return getFirebasePath(basePath, hugoSymbol);
   } else {
-    return getFirebasePath(basePath);
+    return isGermline ? FB_COLLECTION.GERMLINE_GENES : FB_COLLECTION.GENES;
   }
 };
 
@@ -143,11 +143,11 @@ export const getFirebaseHistoryPath = (isGermline: boolean | undefined, hugoSymb
 };
 
 export const getFirebaseVusPath = (isGermline: boolean | undefined, hugoSymbol?: string) => {
-  const basePath = isGermline ? 'GERMLINE_VUS' : 'VUS';
   if (hugoSymbol !== undefined) {
+    const basePath = isGermline ? 'GERMLINE_VUS' : 'VUS';
     return getFirebasePath(basePath, hugoSymbol);
   } else {
-    return getFirebasePath(basePath);
+    return isGermline ? FB_COLLECTION.GERMLINE_VUS : FB_COLLECTION.VUS;
   }
 };
 

--- a/src/main/webapp/app/shared/util/jhipster-types.ts
+++ b/src/main/webapp/app/shared/util/jhipster-types.ts
@@ -15,6 +15,7 @@ export interface IQueryParams {
 export interface ISearchParams extends IQueryParams {
   search?: string;
   exact?: boolean;
+  noState?: boolean;
 }
 export type ICrudGetAllAction<T> = (params: IQueryParams) => IPayload<T[]>;
 export type ICrudSearchAction<T> = (params: ISearchParams) => IPayload<T[]>;

--- a/src/main/webapp/app/shared/util/pagination-crud-store.ts
+++ b/src/main/webapp/app/shared/util/pagination-crud-store.ts
@@ -50,7 +50,7 @@ export class PaginationCrudStore<T extends object> extends BaseCrudStore<T> {
     return result;
   }
 
-  *getSearch({ query, exact, page, size, sort }: ISearchParams) {
+  *getSearch({ query, exact, page, size, sort, noState }: ISearchParams) {
     let url = `${this.apiUrl}/search?query=${query}${page ? `&page=${page}` : ''}${size ? `&size=${size}` : ''}${
       sort ? parseSort(sort) : ''
     }`;
@@ -58,8 +58,10 @@ export class PaginationCrudStore<T extends object> extends BaseCrudStore<T> {
       url = `${url}&exact=${exact}`;
     }
     const result = yield axios.get<T[]>(url);
-    this.entities = result.data;
-    this.totalItems = result.data.length;
+    if (!noState) {
+      this.entities = result.data;
+      this.totalItems = result.data.length;
+    }
     return result;
   }
 }

--- a/src/main/webapp/app/stores/createStore.ts
+++ b/src/main/webapp/app/stores/createStore.ts
@@ -101,10 +101,11 @@ import { FirebaseRepository } from './firebase/firebase-repository';
 import { OpenMutationCollapsibleStore } from './open-mutation-collapsible.store';
 import { CurationPageStore } from 'app/stores/curation-page.store';
 import CategoricalAlterationStore from 'app/entities/categorical-alteration/categorical-alteration.store';
-import { driveAnnotationClient, evidenceClient, geneTypeClient } from 'app/shared/api/clients';
+import { driveAnnotationClient, evidenceClient, geneTypeClient, geneLegacyApi } from 'app/shared/api/clients';
 import { WindowStore } from './window-store';
 /* jhipster-needle-add-store-import - JHipster will add store here */
 import ManagementStore from 'app/stores/management.store';
+import { GeneApi } from 'app/shared/api/manual/gene-api';
 
 export interface IRootStore {
   readonly loadingStore: LoadingBarStore;
@@ -166,6 +167,9 @@ export interface IRootStore {
   readonly firebaseMetaService: FirebaseMetaService;
   readonly firebaseHistoryService: FirebaseHistoryService;
   readonly firebaseVusService: FirebaseVusService;
+
+  /* oncokb-core clients */
+  readonly geneLegacyApi: GeneApi;
 }
 
 export function createStores(history: History): IRootStore {
@@ -267,6 +271,9 @@ export function createStores(history: History): IRootStore {
   rootStore.firebaseGeneReviewService = firebaseGeneReviewService;
   rootStore.firebaseGeneService = firebaseGeneService;
   rootStore.firebaseVusService = firebaseVusService;
+
+  /* oncokb-core clients */
+  rootStore.geneLegacyApi = geneLegacyApi;
 
   /* jhipster-needle-add-store-init - JHipster will add store here */
   return rootStore;

--- a/src/main/webapp/app/stores/createStore.ts
+++ b/src/main/webapp/app/stores/createStore.ts
@@ -253,6 +253,8 @@ export function createStores(history: History): IRootStore {
   const firebaseGeneService = new FirebaseGeneService(
     firebaseRepository,
     rootStore.authStore,
+    rootStore.geneStore,
+    rootStore.drugStore,
     firebaseMutationListStore,
     firebaseMutationConvertIconStore,
     firebaseMetaService,


### PR DESCRIPTION
- [Add releaseGene param when saving gene data to core](https://github.com/oncokb/oncokb-transcript/commit/e989bbd0765ea6240faf3f1090ba7c7315776ea5)
- [Update to allow save all genes](https://github.com/oncokb/oncokb-transcript/commit/78cb4eb532f0c69d0731c3971b92719095317315)
- [Fix excludedRCTs](https://github.com/oncokb/oncokb-transcript/commit/72feac9bf66ecf81a68a74e1b6be5505617a7d38)
- [Add method to undo gene release](https://github.com/oncokb/oncokb-transcript/commit/ea1900e8af6e1c97a10a1e60fb8d2577b550d4b1)

One issue I haven't gotten the chance to fix is that when modify multiple fields of a section, the accept action will use latest data instead of reviewed content when sending the evidence to core. For instance, level 3>4, propagation 4>no, when accept 3>4, the evidence use propagation 4, instead of 3.
This seems to apply to dx/px/tx