### PR TITLE
Add reference to oncokb sop alteration nomenclature in add mutation modal helper

### DIFF
--- a/src/main/webapp/app/shared/links/SopPageLink.tsx
+++ b/src/main/webapp/app/shared/links/SopPageLink.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Linkout } from './Linkout';
+
+const SOP_LINK = 'https://sop.oncokb.org';
+
+export const SopPageLink: React.FunctionComponent<{
+  version?: number;
+}> = props => {
+  let link = SOP_LINK;
+  let defaultContent = 'OncoKB SOP';
+  if (props.version) {
+    link += `/?version=v${props.version}`;
+    defaultContent += ` v${props.version}`;
+  }
+  return <Linkout to={link}>{props.children || defaultContent}</Linkout>;
+};

--- a/src/main/webapp/app/shared/modal/AddMutationModal.tsx
+++ b/src/main/webapp/app/shared/modal/AddMutationModal.tsx
@@ -27,8 +27,8 @@ import classNames from 'classnames';
 import { READABLE_ALTERATION, REFERENCE_GENOME } from 'app/config/constants/constants';
 import { Unsubscribe } from 'firebase/database';
 import Select from 'react-select/dist/declarations/src/Select';
-import DefaultTooltip from '../tooltip/DefaultTooltip';
 import InfoIcon from '../icons/InfoIcon';
+import { Linkout } from '../links/Linkout';
 
 type AlterationData = {
   type: AlterationTypeEnum;
@@ -1174,16 +1174,22 @@ const AddMutationInputOverlay = () => {
         <span style={{ fontStyle: 'italic', fontWeight: 'bold' }}>Add button</span> to annotate alteration(s).
       </div>
       <div className="mt-2">
-        <div>Examples:</div>
+        <div>Supported inputs:</div>
         <div>
           <ul style={{ marginBottom: 0 }}>
             <li>
-              Variant alleles seperated by slash - <span className="text-primary">R132C/H/G/S/L</span>
+              Variant alleles seperated by slash - <span className="text-success">R132C/H/G/S/L</span>
             </li>
             <li>
-              Comma seperated list of alterations - <span className="text-primary">V600E, V600K</span>
+              Comma seperated list of alterations - <span className="text-success">V600E, V600K</span>
             </li>
           </ul>
+        </div>
+        <div className="mt-2">
+          For detailed list, refer to:{' '}
+          <Linkout to={'https://sop.oncokb.org/'}>
+            OncoKB SOP - Chapter 6: Table 3.1: OncoKB alteration nomenclature, style and formatting
+          </Linkout>
         </div>
       </div>
     </div>

--- a/src/main/webapp/app/shared/modal/AddMutationModal.tsx
+++ b/src/main/webapp/app/shared/modal/AddMutationModal.tsx
@@ -29,6 +29,7 @@ import { Unsubscribe } from 'firebase/database';
 import Select from 'react-select/dist/declarations/src/Select';
 import InfoIcon from '../icons/InfoIcon';
 import { Linkout } from '../links/Linkout';
+import { SopPageLink } from '../links/SopPageLink';
 
 type AlterationData = {
   type: AlterationTypeEnum;
@@ -1187,9 +1188,7 @@ const AddMutationInputOverlay = () => {
         </div>
         <div className="mt-2">
           For detailed list, refer to:{' '}
-          <Linkout to={'https://sop.oncokb.org/'}>
-            OncoKB SOP - Chapter 6: Table 3.1: OncoKB alteration nomenclature, style and formatting
-          </Linkout>
+          <SopPageLink>OncoKB SOP - Chapter 6: Table 3.1: OncoKB alteration nomenclature, style and formatting</SopPageLink>
         </div>
       </div>
     </div>


### PR DESCRIPTION
fixes https://github.com/oncokb/oncokb-pipeline/issues/520

I only added a link to the SOP in mutation modal helper icon. I believe the two input examples that we have are the only ones that are not listed in SOP. 