### PR TITLE
Update CDx curation panel to allow combination drugs

### DIFF
--- a/src/main/webapp/app/components/panels/CompanionDiagnosticDevicePanel.tsx
+++ b/src/main/webapp/app/components/panels/CompanionDiagnosticDevicePanel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Menu } from 'react-pro-sidebar';
 import { Button, Container, Form } from 'reactstrap';
-import { ENTITY_ACTION, ENTITY_TYPE, SearchOptionType } from 'app/config/constants/constants';
+import { ENTITY_ACTION, ENTITY_TYPE, RULE_ENTITY, SearchOptionType } from 'app/config/constants/constants';
 import { useHistory, useLocation } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
@@ -13,7 +13,7 @@ import AlterationSelect, { AlterationSelectOption } from 'app/shared/select/Alte
 import DrugSelect, { DrugSelectOption } from 'app/shared/select/DrugSelect';
 import FdaSubmissionSelect, { FdaSubmissionSelectOption } from 'app/shared/select/FdaSubmissionSelect';
 import { getEntityActionRoute } from 'app/shared/util/RouteUtils';
-import { Alteration, Association, CancerType, Drug, FdaSubmission } from 'app/shared/api/generated/curation';
+import { Alteration, Association, CancerType, Drug, FdaSubmission, Rule } from 'app/shared/api/generated/curation';
 import { associationClient } from 'app/shared/api/clients';
 import { notifyError, notifySuccess } from 'app/oncokb-commons/components/util/NotificationUtils';
 import { IRootStore } from 'app/stores';
@@ -82,6 +82,14 @@ const CompanionDiagnosticDevicePanel: React.FunctionComponent<StoreProps> = ({ g
         };
       }),
     };
+
+    if (association.drugs) {
+      const rule: Rule = {
+        entity: RULE_ENTITY.DRUG,
+        rule: association.drugs.map(drug => drug.id).join('+'),
+      };
+      association.rules = [rule];
+    }
 
     if (cancerTypeValue) {
       association.cancerTypes = [{ id: cancerTypeValue.value } as CancerType];

--- a/src/main/webapp/app/config/constants/constants.ts
+++ b/src/main/webapp/app/config/constants/constants.ts
@@ -339,6 +339,11 @@ export enum USER_AUTHORITY {
   ROLE_CURATOR = 'ROLE_CURATOR',
 }
 
+export enum RULE_ENTITY {
+  DRUG = 'DRUG',
+  CANCER_TYPE = 'CANCER_TYPE',
+}
+
 export const DEFAULT_SORT_PARAMETER = 'id,ASC';
 
 export const DEFAULT_SORT_DIRECTION = 'ASC';


### PR DESCRIPTION
As a quick fix, we will convert the drug select on CDx panel to input combination drugs instead of list of treaments (comma seperated). 
There will be a followup PR to address adding both combination drugs and multiple treatments. (Same interface as add therapy modal on curation page) https://github.com/oncokb/oncokb-pipeline/issues/588