### PR TITLE
Meta review should be created by default

### DIFF
--- a/src/main/webapp/app/shared/model/firebase/firebase.model.ts
+++ b/src/main/webapp/app/shared/model/firebase/firebase.model.ts
@@ -399,7 +399,7 @@ export class Meta {
   lastSavedAt?: number;
   lastSavedBy?: string;
   movingSection?: boolean;
-  review?: MetaReview;
+  review: MetaReview = new MetaReview();
 }
 
 export class MetaReview {


### PR DESCRIPTION
Meta.review should be initialized so that meta.review.currentReviewer is set to empty string.