### PR TITLE
Add keycloak idp mapper for picture attribute

### DIFF
--- a/src/main/docker/realm-config/oncokb-curation-realm.json
+++ b/src/main/docker/realm-config/oncokb-curation-realm.json
@@ -1346,7 +1346,19 @@
       }
     }
   ],
-  "identityProviderMappers": [],
+  "identityProviderMappers": [
+    {
+      "id": "4f2bdff6-b374-472a-9ede-afcc575c311b",
+      "name": "picture",
+      "identityProviderAlias": "google",
+      "identityProviderMapper": "google-user-attribute-mapper",
+      "config": {
+        "syncMode": "INHERIT",
+        "jsonField": "picture",
+        "userAttribute": "picture"
+      }
+    }
+  ],
   "components": {
     "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
       {

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -211,7 +211,7 @@ jhipster:
     license: 'Terms of Use'
     license-url: 'https://www.oncokb.org/terms'
   security:
-    content-security-policy: "default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com https://*.firebaseio.com https://www.googletagmanager.com https://*.heapanalytics.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://*.google.com https://heapanalytics.com; font-src 'self' data: https://cdnjs.cloudflare.com; connect-src 'self' ws://*.firebaseio.com https://*;"
+    content-security-policy: "default-src 'self'; frame-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://storage.googleapis.com https://*.firebaseio.com https://www.googletagmanager.com https://*.heapanalytics.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https://*.google.com https://heapanalytics.com https://*.googleusercontent.com; font-src 'self' data: https://cdnjs.cloudflare.com; connect-src 'self' ws://*.firebaseio.com https://*;"
     oauth2:
       audience:
         - account


### PR DESCRIPTION
In order for the picture from google to be mapped properly, we have to add a mapper in Keycloak.
This PR updates the realm-config json to reflect this change. Profile image is now visible on production curation website (after re-logging)

@bprize15 Could you verify that picture shows up fine for you?