### PR TITLE
Create script to backfill all oncokb canonical transcripts

### DIFF
--- a/src/main/java/org/mskcc/oncokb/curation/OncokbCurationApp.java
+++ b/src/main/java/org/mskcc/oncokb/curation/OncokbCurationApp.java
@@ -143,16 +143,6 @@ public class OncokbCurationApp {
         }
     }
 
-    @PostConstruct
-    public void importTranscriptFlags() {
-        Collection<String> activeProfiles = Arrays.asList(
-            env.getActiveProfiles().length == 0 ? env.getDefaultProfiles() : env.getActiveProfiles()
-        );
-        if (activeProfiles.contains("transcript-flag-importer")) {
-            canonicalTranscriptFlagImporter.importCanonicalTranscripts();
-        }
-    }
-
     /**
      * Main method, used to run the application.
      *

--- a/src/main/java/org/mskcc/oncokb/curation/OncokbCurationApp.java
+++ b/src/main/java/org/mskcc/oncokb/curation/OncokbCurationApp.java
@@ -16,7 +16,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.mskcc.oncokb.curation.config.CRLFLogConverter;
 import org.mskcc.oncokb.curation.config.application.ApplicationProperties;
 import org.mskcc.oncokb.curation.config.application.FrontendProperties;
-import org.mskcc.oncokb.curation.importer.CanonicalTranscriptFlagImporter;
 import org.mskcc.oncokb.curation.importer.CdxImporter;
 import org.mskcc.oncokb.curation.importer.Importer;
 import org.oncokb.ApiException;
@@ -43,9 +42,6 @@ public class OncokbCurationApp {
 
     @Autowired
     CdxImporter cdxImporter;
-
-    @Autowired
-    CanonicalTranscriptFlagImporter canonicalTranscriptFlagImporter;
 
     private static final Logger log = LoggerFactory.getLogger(OncokbCurationApp.class);
 

--- a/src/main/java/org/mskcc/oncokb/curation/OncokbCurationApp.java
+++ b/src/main/java/org/mskcc/oncokb/curation/OncokbCurationApp.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.mskcc.oncokb.curation.config.CRLFLogConverter;
 import org.mskcc.oncokb.curation.config.application.ApplicationProperties;
 import org.mskcc.oncokb.curation.config.application.FrontendProperties;
+import org.mskcc.oncokb.curation.importer.CanonicalTranscriptFlagImporter;
 import org.mskcc.oncokb.curation.importer.CdxImporter;
 import org.mskcc.oncokb.curation.importer.Importer;
 import org.oncokb.ApiException;
@@ -42,6 +43,9 @@ public class OncokbCurationApp {
 
     @Autowired
     CdxImporter cdxImporter;
+
+    @Autowired
+    CanonicalTranscriptFlagImporter canonicalTranscriptFlagImporter;
 
     private static final Logger log = LoggerFactory.getLogger(OncokbCurationApp.class);
 
@@ -136,6 +140,16 @@ public class OncokbCurationApp {
         );
         if (activeProfiles.contains("cdx-importer")) {
             cdxImporter.importCdxMain();
+        }
+    }
+
+    @PostConstruct
+    public void importTranscriptFlags() {
+        Collection<String> activeProfiles = Arrays.asList(
+            env.getActiveProfiles().length == 0 ? env.getDefaultProfiles() : env.getActiveProfiles()
+        );
+        if (activeProfiles.contains("transcript-flag-importer")) {
+            canonicalTranscriptFlagImporter.importCanonicalTranscripts();
         }
     }
 

--- a/src/main/java/org/mskcc/oncokb/curation/importer/CanonicalTranscriptFlagImporter.java
+++ b/src/main/java/org/mskcc/oncokb/curation/importer/CanonicalTranscriptFlagImporter.java
@@ -114,7 +114,7 @@ public class CanonicalTranscriptFlagImporter {
             }
             log.info(String.format("Successfully saved transcript %s %s %s", isoform, refSeq, referenceGenome.toString()));
         } else {
-            log.info("Creating new");
+            log.warn("Transcript does not exist in database, skipping...");
         }
     }
 }

--- a/src/main/java/org/mskcc/oncokb/curation/importer/CanonicalTranscriptFlagImporter.java
+++ b/src/main/java/org/mskcc/oncokb/curation/importer/CanonicalTranscriptFlagImporter.java
@@ -29,12 +29,8 @@ public class CanonicalTranscriptFlagImporter {
     final String ONCOKB_GENE_LIST_FILE_PATH = "data/oncokb_core/cancer_gene_list_v4_23.tsv";
 
     final GeneService geneService;
-    final GenomeNexusService genomeNexusService;
-    final EnsemblGeneService ensemblGeneService;
     final TranscriptService transcriptService;
     final FlagService flagService;
-    final InfoService infoService;
-    final MainService mainService;
 
     public CanonicalTranscriptFlagImporter(
         GeneService geneService,
@@ -46,12 +42,8 @@ public class CanonicalTranscriptFlagImporter {
         MainService mainService
     ) {
         this.geneService = geneService;
-        this.genomeNexusService = genomeNexusService;
-        this.ensemblGeneService = ensemblGeneService;
         this.transcriptService = transcriptService;
         this.flagService = flagService;
-        this.infoService = infoService;
-        this.mainService = mainService;
     }
 
     public void importCanonicalTranscripts() {

--- a/src/main/java/org/mskcc/oncokb/curation/importer/CanonicalTranscriptFlagImporter.java
+++ b/src/main/java/org/mskcc/oncokb/curation/importer/CanonicalTranscriptFlagImporter.java
@@ -1,0 +1,128 @@
+package org.mskcc.oncokb.curation.importer;
+
+import static org.mskcc.oncokb.curation.util.FileUtils.readDelimitedLinesStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.mskcc.oncokb.curation.domain.Flag;
+import org.mskcc.oncokb.curation.domain.Transcript;
+import org.mskcc.oncokb.curation.domain.enumeration.FlagType;
+import org.mskcc.oncokb.curation.domain.enumeration.ReferenceGenome;
+import org.mskcc.oncokb.curation.service.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * To backfill the OncoKB canonical transcripts
+ */
+
+@Component
+public class CanonicalTranscriptFlagImporter {
+
+    private final Logger log = LoggerFactory.getLogger(CanonicalTranscriptFlagImporter.class);
+
+    final String ONCOKB_GENE_LIST_FILE_PATH = "data/oncokb_core/cancer_gene_list_v4_23.tsv";
+
+    final GeneService geneService;
+    final GenomeNexusService genomeNexusService;
+    final EnsemblGeneService ensemblGeneService;
+    final TranscriptService transcriptService;
+    final FlagService flagService;
+    final InfoService infoService;
+    final MainService mainService;
+
+    public CanonicalTranscriptFlagImporter(
+        GeneService geneService,
+        GenomeNexusService genomeNexusService,
+        EnsemblGeneService ensemblGeneService,
+        TranscriptService transcriptService,
+        FlagService flagService,
+        InfoService infoService,
+        MainService mainService
+    ) {
+        this.geneService = geneService;
+        this.genomeNexusService = genomeNexusService;
+        this.ensemblGeneService = ensemblGeneService;
+        this.transcriptService = transcriptService;
+        this.flagService = flagService;
+        this.infoService = infoService;
+        this.mainService = mainService;
+    }
+
+    public void importCanonicalTranscripts() {
+        URL geneListUrl = getClass().getClassLoader().getResource(ONCOKB_GENE_LIST_FILE_PATH);
+        try {
+            InputStream is = geneListUrl.openStream();
+            List<List<String>> tsvFile = readDelimitedLinesStream(is, "\t", true);
+            for (int i = 0; i < tsvFile.size(); i++) {
+                if (i == 0) {
+                    continue;
+                }
+                List<String> line = tsvFile.get(i);
+                if (line.size() < 8) {
+                    log.warn(String.format("Skipping line %i", i));
+                    continue;
+                }
+                Integer entrezGeneId;
+                if (StringUtils.isNumeric(line.get(1))) {
+                    entrezGeneId = Integer.parseInt(line.get(1), 10);
+                } else {
+                    log.warn(String.format("Entrez Id not found on line %i", i));
+                    continue;
+                }
+
+                String grch37Isoform = line.get(2);
+                String grch37RefSeq = line.get(3);
+                if (StringUtils.isBlank(grch37Isoform)) {
+                    log.warn(String.format("No GRCh37 isoform found for gene %s, skipping...", line.get(0)));
+                } else {
+                    findAndSaveTranscriptInfo(entrezGeneId, grch37Isoform, grch37RefSeq, ReferenceGenome.GRCh37);
+                }
+
+                String grch38Isoform = line.get(4);
+                String grch38RefSeq = line.get(5);
+                if (StringUtils.isBlank(grch38Isoform)) {
+                    log.warn(String.format("No GRCh38 isoform found for gene %s, skipping...", line.get(0)));
+                } else {
+                    findAndSaveTranscriptInfo(entrezGeneId, grch38Isoform, grch38RefSeq, ReferenceGenome.GRCh38);
+                }
+            }
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+    }
+
+    private void findAndSaveTranscriptInfo(Integer entrezGeneId, String isoform, String refSeq, ReferenceGenome referenceGenome) {
+        List<Transcript> transcripts = transcriptService
+            .findByEntrezGeneIdAndReferenceGenome(entrezGeneId, referenceGenome)
+            .stream()
+            .filter(transcript -> transcript.getEnsemblTranscriptId().startsWith(isoform))
+            .collect(Collectors.toList());
+        Flag oncokbCanonicalFlag = flagService.findByTypeAndFlag(FlagType.TRANSCRIPT, "ONCOKB").orElseThrow();
+        Transcript transcript;
+        if (transcripts.size() > 0) {
+            if (transcripts.size() > 1) {
+                log.warn("Found more than one matching transcripts with different subversions, skipping...");
+                return;
+            }
+            transcript = transcripts.get(0);
+            transcript.setCanonical(true);
+            transcript.setEnsemblTranscriptId(isoform);
+            transcript.setReferenceSequenceId(refSeq);
+            transcript.getFlags().add(oncokbCanonicalFlag);
+            try {
+                transcriptService.save(transcript);
+            } catch (Exception e) {
+                log.error(e.getMessage());
+            }
+            log.info(String.format("Successfully saved transcript %s %s %s", isoform, refSeq, referenceGenome.toString()));
+        } else {
+            log.info("Creating new");
+        }
+    }
+}

--- a/src/main/java/org/mskcc/oncokb/curation/importer/CanonicalTranscriptFlagImporter.java
+++ b/src/main/java/org/mskcc/oncokb/curation/importer/CanonicalTranscriptFlagImporter.java
@@ -15,6 +15,8 @@ import org.mskcc.oncokb.curation.domain.enumeration.ReferenceGenome;
 import org.mskcc.oncokb.curation.service.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
@@ -22,11 +24,12 @@ import org.springframework.stereotype.Component;
  */
 
 @Component
-public class CanonicalTranscriptFlagImporter {
+@Profile("transcript-flag-importer")
+public class CanonicalTranscriptFlagImporter implements CommandLineRunner {
 
     private final Logger log = LoggerFactory.getLogger(CanonicalTranscriptFlagImporter.class);
 
-    final String ONCOKB_GENE_LIST_FILE_PATH = "data/oncokb_core/cancer_gene_list_v4_23.tsv";
+    final String ONCOKB_GENE_LIST_FILE_PATH = "data/oncokb_core/cancer_gene_list_v4_24.tsv";
 
     final GeneService geneService;
     final TranscriptService transcriptService;
@@ -46,7 +49,14 @@ public class CanonicalTranscriptFlagImporter {
         this.flagService = flagService;
     }
 
-    public void importCanonicalTranscripts() {
+    @Override
+    public void run(String... args) throws Exception {
+        log.info("Running canonical transcript flag importer...");
+        importCanonicalTranscripts();
+        log.info("Finished importer.");
+    }
+
+    private void importCanonicalTranscripts() {
         URL geneListUrl = getClass().getClassLoader().getResource(ONCOKB_GENE_LIST_FILE_PATH);
         try {
             InputStream is = geneListUrl.openStream();
@@ -57,8 +67,7 @@ public class CanonicalTranscriptFlagImporter {
                 }
                 List<String> line = tsvFile.get(i);
                 if (line.size() < 8) {
-                    log.warn(String.format("Skipping line %i", i));
-                    continue;
+                    throw new IOException(String.format("Line %i has less than 8 columns", i));
                 }
                 Integer entrezGeneId;
                 if (StringUtils.isNumeric(line.get(1))) {

--- a/src/main/java/org/mskcc/oncokb/curation/repository/TranscriptRepository.java
+++ b/src/main/java/org/mskcc/oncokb/curation/repository/TranscriptRepository.java
@@ -27,8 +27,10 @@ public interface TranscriptRepository extends JpaRepository<Transcript, Long>, J
 
     List<Transcript> findByEnsemblGene(EnsemblGene ensemblGene);
 
-    @Query("select distinct t from Transcript t join t.ensemblGene eg where eg.referenceGenome= ?1 and t.ensemblTranscriptId in ?2")
-    List<Transcript> findByEnsemblGeneId(Integer entrezGeneId);
+    @Query(
+        "select distinct t from Transcript t left join fetch t.flags left join t.gene g where t.referenceGenome=?2 and g.entrezGeneId=?1"
+    )
+    List<Transcript> findByEntrezGeneIdAndReferenceGenome(Integer entrezGeneId, ReferenceGenome referenceGenome);
 
     Optional<Transcript> findByEnsemblGeneAndEnsemblTranscriptId(EnsemblGene ensemblGene, String ensemblTranscriptId);
 

--- a/src/main/java/org/mskcc/oncokb/curation/service/TranscriptService.java
+++ b/src/main/java/org/mskcc/oncokb/curation/service/TranscriptService.java
@@ -285,6 +285,11 @@ public class TranscriptService {
         return transcriptMapper.toDto(transcriptRepository.findByEnsemblGene(ensemblGene));
     }
 
+    @Transactional(readOnly = true)
+    public List<Transcript> findByEntrezGeneIdAndReferenceGenome(Integer entrezGeneId, ReferenceGenome referenceGenome) {
+        return transcriptRepository.findByEntrezGeneIdAndReferenceGenome(entrezGeneId, referenceGenome);
+    }
+
     public List<EnsemblTranscript> getTranscriptsWithMatchedResidue(
         ReferenceGenome referenceGenome,
         List<EnsemblTranscript> transcripts,

--- a/src/main/webapp/app/pages/curation/header/GeneHeader.tsx
+++ b/src/main/webapp/app/pages/curation/header/GeneHeader.tsx
@@ -104,7 +104,7 @@ const GeneHeader = ({ firebaseGenePath, geneEntity, isReviewing }: IGeneHeaderPr
                   {(transcriptInfoByReferenceGenome[REFERENCE_GENOME.GRCH37].ensemblTranscriptId ||
                     transcriptInfoByReferenceGenome[REFERENCE_GENOME.GRCH38].ensemblTranscriptId) && (
                     <div className="d-flex">
-                      <div>Ensembl Transcript: </div>
+                      <div className="me-1">Ensembl Transcript:</div>
                       <EnsemblIdText
                         grch37={transcriptInfoByReferenceGenome[REFERENCE_GENOME.GRCH37].ensemblTranscriptId}
                         grch38={transcriptInfoByReferenceGenome[REFERENCE_GENOME.GRCH38].ensemblTranscriptId}
@@ -114,7 +114,7 @@ const GeneHeader = ({ firebaseGenePath, geneEntity, isReviewing }: IGeneHeaderPr
                   {(transcriptInfoByReferenceGenome[REFERENCE_GENOME.GRCH37].referenceSequenceId ||
                     transcriptInfoByReferenceGenome[REFERENCE_GENOME.GRCH38].referenceSequenceId) && (
                     <div className="d-flex">
-                      <div>Ref Seq:</div>
+                      <div className="me-1">Ref Seq:</div>
                       <RefSeqText
                         grch37={transcriptInfoByReferenceGenome[REFERENCE_GENOME.GRCH37].referenceSequenceId}
                         grch38={transcriptInfoByReferenceGenome[REFERENCE_GENOME.GRCH38].referenceSequenceId}


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb-pipeline/issues/262

Import the cancer gene list from oncokb core, which has all the oncokb preferred transcripts and reference sequence ids. Backfill in the `OncoKB Canonical` transcript flag and also the refseq ids if they don't exist.

For future releases, we will allow the data releaser to mark the chosen transcripts as canonical as part of data release procedure. [Tracked here](https://github.com/oncokb/oncokb-pipeline/issues/634). 