### PR TITLE
Handle case when name_review does not exist

### DIFF
--- a/src/main/webapp/app/service/firebase/firebase-gene-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-service.ts
@@ -408,20 +408,28 @@ export class FirebaseGeneService {
   };
 
   updateMutationName = async (mutationPath: string, allMutationsPath: string, currentMutationName: string, mutation: Mutation) => {
-    const { name_review } = mutation;
-    if (name_review) {
-      await this.firebaseRepository.update(mutationPath, mutation).then(() => {
-        this.firebaseGeneReviewService.updateReviewableContent(
-          `${mutationPath}/name`,
-          currentMutationName,
-          mutation.name,
-          name_review,
-          mutation.name_uuid,
-        );
-      });
+    let { name_review } = mutation;
+    let mutationToUpdate = mutation;
 
-      await this.firebaseMutationConvertIconStore.fetchData(allMutationsPath);
+    if (!name_review) {
+      name_review = new Review(this.authStore.fullName);
+
+      mutationToUpdate = {
+        ...mutation,
+        name_review,
+      };
     }
+    await this.firebaseRepository.update(mutationPath, mutationToUpdate).then(() => {
+      this.firebaseGeneReviewService.updateReviewableContent(
+        `${mutationPath}/name`,
+        currentMutationName,
+        mutationToUpdate.name,
+        name_review,
+        mutationToUpdate.name_uuid,
+      );
+    });
+
+    await this.firebaseMutationConvertIconStore.fetchData(allMutationsPath);
   };
 
   /**


### PR DESCRIPTION
Fixes https://github.com/oncokb/oncokb-pipeline/issues/783
Issue: Mutation was added a long time ago via old curation platform. Some bug caused `name_review` to not exist, so we are just handling the edge case here. Should probably fix the data at some point too.