### PR TITLE
Fixed infinite re-rendering when you delete a cancer type

### DIFF
--- a/src/main/webapp/app/pages/curation/list/FirebaseList.tsx
+++ b/src/main/webapp/app/pages/curation/list/FirebaseList.tsx
@@ -60,10 +60,14 @@ function FirebaseList<T>({ path, itemBuilder, pushDirection, scrollOptions, filt
       if (!snapshot.val() || !listItemKeys) {
         return;
       }
-
       const currentKeys = Object.keys(snapshot.val() as Record<string, T>);
-      if (currentKeys.length !== listItemKeys.length + addedListItemKeys.length) {
-        setAddedListItemKeys(currentKeys.filter(x => !listItemKeys.includes(x)));
+      const newKeys = currentKeys.filter(x => !listItemKeys.includes(x));
+
+      // Only update if newKeys differ from addedListItemKeys
+      const sameLength = newKeys.length === addedListItemKeys.length;
+      const sameContent = sameLength && newKeys.every(x => addedListItemKeys.includes(x));
+      if (!sameContent) {
+        setAddedListItemKeys(newKeys);
       }
     });
 


### PR DESCRIPTION
Issue: An infinite re-render loop was caused when a key was deleted because `addedListItemKeys` became an empty array `[]`.

Fix: Compare the new filtered keys with the current `addedListItemKeys` by checking both length and content equality. Update `addedListItemKeys` only if they are different.

Previous PR: https://github.com/oncokb/oncokb-transcript/pull/532