### PR TITLE
Keep review page in sync with Firebase during review

### DIFF
--- a/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
+++ b/src/main/webapp/app/pages/curation/review/ReviewPage.tsx
@@ -10,7 +10,7 @@ import { getFirebaseGenePath, getFirebaseMetaGenePath } from 'app/shared/util/fi
 import { componentInject } from 'app/shared/util/typed-inject';
 import { getSectionClassName, useDrugListRef } from 'app/shared/util/utils';
 import { IRootStore } from 'app/stores';
-import { get, ref, set } from 'firebase/database';
+import { onValue, ref, set } from 'firebase/database';
 import { observer } from 'mobx-react';
 import React, { useEffect, useState } from 'react';
 import { Alert, Col, Row } from 'reactstrap';
@@ -51,23 +51,30 @@ const ReviewPage: React.FunctionComponent<IReviewPageProps> = (props: IReviewPag
   const [editorsToAcceptChangesFrom, setEditorsToAcceptChangesFrom] = useState<string[]>([]);
   const [isAcceptingAll, setIsAcceptingAll] = useState(false);
 
-  const fetchFirebaseData = async () => {
-    if (!props.firebaseDb) {
+  useEffect(() => {
+    if (!geneEntity || !props.firebaseInitSuccess || !props.firebaseDb || !hugoSymbol) {
       return;
     }
-    // Fetch the data when the user enters review mode. We don't use a listener
-    // because there shouldn't be another user editing the gene when it is being reviewed.
-    const geneDataSnapshot = await get(ref(props.firebaseDb, firebaseGenePath));
-    setGeneData(geneDataSnapshot.val());
-    const metaReviewSnapshot = await get(ref(props.firebaseDb, firebaseMetaReviewPath));
-    setMetaReview(metaReviewSnapshot.val());
-  };
 
-  useEffect(() => {
-    if (geneEntity && props.firebaseInitSuccess) {
-      fetchFirebaseData();
-    }
-  }, [geneEntity, props.firebaseDb, props.firebaseInitSuccess]);
+    const geneRef = ref(props.firebaseDb, firebaseGenePath);
+    const metaReviewRef = ref(props.firebaseDb, firebaseMetaReviewPath);
+
+    // Review mode still needs live listeners because changes to the gene or review meta can
+    // change the computed root review tree. Components under ReviewCollapsible rely on that
+    // root value updating so they rerender against current Firebase state, even if only one
+    // reviewer is expected to be editing the gene at a time.
+    const unsubscribeGene = onValue(geneRef, snapshot => {
+      setGeneData(snapshot.val());
+    });
+    const unsubscribeMetaReview = onValue(metaReviewRef, snapshot => {
+      setMetaReview(snapshot.val());
+    });
+
+    return () => {
+      unsubscribeGene();
+      unsubscribeMetaReview();
+    };
+  }, [geneEntity, props.firebaseDb, props.firebaseInitSuccess, firebaseGenePath, firebaseMetaReviewPath, hugoSymbol]);
 
   const drugListRef = useDrugListRef(props.drugList);
 
@@ -159,7 +166,6 @@ const ReviewPage: React.FunctionComponent<IReviewPageProps> = (props: IReviewPag
         isGermline: isGermline ?? false,
         isAcceptAll: true,
       });
-      await fetchFirebaseData();
     } catch (error) {
       notifyError(error);
     } finally {

--- a/src/main/webapp/app/service/firebase/firebase-gene-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-service.ts
@@ -690,7 +690,8 @@ export class FirebaseGeneService {
     } catch (e) {
       /* eslint-disable no-console */
       console.error(e);
-      throw new SentryError('Failed to save gene ', { entrezGeneIds });
+      // avoid annoying dev error page when you are not connected to staging core.
+      notifyError(new SentryError('Failed to save gene to Staging', { entrezGeneIds }));
     }
     return;
   };


### PR DESCRIPTION
Closes https://github.com/oncokb/oncokb-pipeline/issues/1116

AI Generated Summary:

Rejecting one review item could leave stale review state in ReviewPage, so later accepts were still operating on an outdated root review tree. In the repro case, rejecting the description and then accepting oncogenicity/pathogenicity caused the old description data to remain on the curation page because the review UI was not re-synced from Firebase after those changes.

This change switches the review page from one-time Firebase reads to live listeners for both gene data and review metadata. That keeps the computed root review tree current as review actions update Firebase, so child components rerender against fresh state and rejected fields do not get reintroduced by subsequent review actions. It also keeps the accept-all flow aligned with the listener-based refresh model and softens the staging save failure path so local review work is not interrupted by staging connectivity issues.
