### PR TITLE
Default null protein positions in annotate-alterations response

### DIFF
--- a/src/main/java/org/mskcc/oncokb/curation/web/rest/AlterationController.java
+++ b/src/main/java/org/mskcc/oncokb/curation/web/rest/AlterationController.java
@@ -1,12 +1,8 @@
 package org.mskcc.oncokb.curation.web.rest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.mskcc.oncokb.curation.domain.Alteration;
 import org.mskcc.oncokb.curation.domain.AlterationAnnotationStatus;
-import org.mskcc.oncokb.curation.domain.EntityStatus;
 import org.mskcc.oncokb.curation.service.MainService;
 import org.mskcc.oncokb.curation.web.rest.model.AnnotateAlterationBody;
 import org.slf4j.Logger;
@@ -18,6 +14,9 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api")
 public class AlterationController {
+
+    private static final int DEFAULT_PROTEIN_START = -1;
+    private static final int DEFAULT_PROTEIN_END = 100_000;
 
     private final Logger log = LoggerFactory.getLogger(AlterationController.class);
 
@@ -40,9 +39,22 @@ public class AlterationController {
                 alterationBody.getAlteration()
             );
             annotationStatus.setQueryId(alterationBody.getQueryId());
+            setDefaultProteinPositions(annotationStatus);
             status.add(annotationStatus);
         });
 
         return new ResponseEntity<>(status, HttpStatus.OK);
+    }
+
+    private void setDefaultProteinPositions(AlterationAnnotationStatus annotationStatus) {
+        if (annotationStatus.getEntity() == null) {
+            return;
+        }
+        if (annotationStatus.getEntity().getStart() == null) {
+            annotationStatus.getEntity().setStart(DEFAULT_PROTEIN_START);
+        }
+        if (annotationStatus.getEntity().getEnd() == null) {
+            annotationStatus.getEntity().setEnd(DEFAULT_PROTEIN_END);
+        }
     }
 }

--- a/src/test/java/org/mskcc/oncokb/curation/web/rest/AlterationControllerTest.java
+++ b/src/test/java/org/mskcc/oncokb/curation/web/rest/AlterationControllerTest.java
@@ -1,0 +1,58 @@
+package org.mskcc.oncokb.curation.web.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mskcc.oncokb.curation.domain.Alteration;
+import org.mskcc.oncokb.curation.domain.AlterationAnnotationStatus;
+import org.mskcc.oncokb.curation.domain.enumeration.ReferenceGenome;
+import org.mskcc.oncokb.curation.service.MainService;
+import org.mskcc.oncokb.curation.web.rest.model.AnnotateAlterationBody;
+
+@ExtendWith(MockitoExtension.class)
+class AlterationControllerTest {
+
+    @Mock
+    private MainService mainService;
+
+    @Test
+    void annotateAlterationsDefaultsNullProteinStartAndEnd() {
+        Alteration alteration = new Alteration();
+        AlterationAnnotationStatus annotationStatus = new AlterationAnnotationStatus();
+        annotationStatus.setEntity(alteration);
+        when(mainService.annotateAlteration(any(), any())).thenReturn(annotationStatus);
+
+        AlterationController controller = new AlterationController(mainService);
+        Alteration result = controller.annotateAlterations(List.of(createRequest())).getBody().get(0).getEntity();
+
+        assertThat(result.getStart()).isEqualTo(-1);
+        assertThat(result.getEnd()).isEqualTo(100_000);
+    }
+
+    @Test
+    void annotateAlterationsPreservesNonNullProteinStartAndEnd() {
+        Alteration alteration = new Alteration().start(600).end(601);
+        AlterationAnnotationStatus annotationStatus = new AlterationAnnotationStatus();
+        annotationStatus.setEntity(alteration);
+        when(mainService.annotateAlteration(any(), any())).thenReturn(annotationStatus);
+
+        AlterationController controller = new AlterationController(mainService);
+        Alteration result = controller.annotateAlterations(List.of(createRequest())).getBody().get(0).getEntity();
+
+        assertThat(result.getStart()).isEqualTo(600);
+        assertThat(result.getEnd()).isEqualTo(601);
+    }
+
+    private AnnotateAlterationBody createRequest() {
+        AnnotateAlterationBody request = new AnnotateAlterationBody();
+        request.setReferenceGenome(ReferenceGenome.GRCh37);
+        request.setAlteration(new Alteration());
+        return request;
+    }
+}


### PR DESCRIPTION
Default null protein positions in /api/annotate-alterations and add focused controller coverage.

  - return start = -1 when annotated protein start resolves to null
  - return end = 100000 when annotated protein end resolves to null
  - preserve existing non-null protein positions
  - add AlterationControllerTest covering both defaulting and preservation paths
