### PR TITLE
Fix placement of ref in editor

### DIFF
--- a/src/main/webapp/app/shared/rich-text-editor/RichTextEditor.tsx
+++ b/src/main/webapp/app/shared/rich-text-editor/RichTextEditor.tsx
@@ -15,12 +15,19 @@ export interface RichTextEditorChange {
 
 export type RichTextPasteHandler = (text: string, editor: Editor) => boolean;
 
+export interface RichTextSelectionRange {
+  from: number;
+  to: number;
+}
+
 interface RichTextEditorContextValue {
   editor: Editor | null;
   disabled: boolean;
   activeToolbarPopover: string | null;
   setActiveToolbarPopover: React.Dispatch<React.SetStateAction<string | null>>;
   editorWrapperRef: React.RefObject<HTMLDivElement>;
+  saveEditorSelection: () => void;
+  getSavedEditorSelection: () => RichTextSelectionRange | null;
 }
 
 const RichTextEditorContext = createContext<RichTextEditorContextValue | undefined>(undefined);
@@ -64,6 +71,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
   const [activeToolbarPopover, setActiveToolbarPopover] = useState<string | null>(null);
   const [isEditorFocused, setIsEditorFocused] = useState(false);
   const editorWrapperRef = useRef<HTMLDivElement>(null);
+  const savedEditorSelectionRef = useRef<RichTextSelectionRange | null>(null);
   const configuredExtensions = useMemo(
     () => [
       // tiptap comes out the box with some of the basic text formattings, but we're
@@ -124,6 +132,14 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
     editor?.setEditable(!disabled);
   }, [disabled, editor]);
 
+  const saveEditorSelection = () => {
+    if (!editor) return;
+    const { from, to } = editor.state.selection;
+    savedEditorSelectionRef.current = { from, to };
+  };
+
+  const getSavedEditorSelection = () => savedEditorSelectionRef.current;
+
   useEffect(() => {
     // when we click anywhere other than the toolbar popover, we want to close the popover
     if (!activeToolbarPopover) return;
@@ -141,6 +157,8 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
     activeToolbarPopover,
     setActiveToolbarPopover,
     editorWrapperRef,
+    saveEditorSelection,
+    getSavedEditorSelection,
   };
 
   return (

--- a/src/main/webapp/app/shared/rich-text-editor/addons/LinkToolbarAddon.tsx
+++ b/src/main/webapp/app/shared/rich-text-editor/addons/LinkToolbarAddon.tsx
@@ -10,18 +10,20 @@ export { GenericLink as genericLinkExtension };
 const POPOVER_ID = 'link';
 
 export const LinkToolbarAddon: React.FC = () => {
-  const { activeToolbarPopover, setActiveToolbarPopover, editor } = useRichTextEditorContext();
+  const { activeToolbarPopover, setActiveToolbarPopover, editor, saveEditorSelection, getSavedEditorSelection } =
+    useRichTextEditorContext();
   const [linkUrl, setLinkUrl] = useState('');
   const isOpen = activeToolbarPopover === POPOVER_ID;
 
   const insertGenericLink = () => {
     const href = normalizeHttpUrl(linkUrl);
     if (!href || !editor || !isSafeHttpUrl(href)) return;
-    editor
-      .chain()
-      .focus()
-      .insertContent({ type: 'genericLink', attrs: { href, text: href } })
-      .run();
+    const selection = getSavedEditorSelection();
+    const chain = editor.chain().focus();
+    if (selection) {
+      chain.setTextSelection(selection.from);
+    }
+    chain.insertContent({ type: 'genericLink', attrs: { href, text: href } }).run();
     setLinkUrl('');
     setActiveToolbarPopover(null);
   };
@@ -33,6 +35,7 @@ export const LinkToolbarAddon: React.FC = () => {
         className={classNames(styles.toolbarBtn, isOpen && styles.active)}
         onMouseDown={event => {
           event.preventDefault();
+          saveEditorSelection();
           setActiveToolbarPopover(panel => (panel === POPOVER_ID ? null : POPOVER_ID));
         }}
         title="Link"

--- a/src/main/webapp/app/shared/rich-text-editor/addons/LinkToolbarAddon.tsx
+++ b/src/main/webapp/app/shared/rich-text-editor/addons/LinkToolbarAddon.tsx
@@ -4,6 +4,7 @@ import * as styles from '../RichTextEditor.module.scss';
 import { useRichTextEditorContext } from '../RichTextEditor';
 import { isSafeHttpUrl, normalizeHttpUrl } from '../utils';
 import { GenericLink } from './ReferenceNodeExtensions';
+import { insertAtSavedEditorSelection } from './ReferenceToolbarAddon';
 
 export { GenericLink as genericLinkExtension };
 
@@ -18,12 +19,7 @@ export const LinkToolbarAddon: React.FC = () => {
   const insertGenericLink = () => {
     const href = normalizeHttpUrl(linkUrl);
     if (!href || !editor || !isSafeHttpUrl(href)) return;
-    const selection = getSavedEditorSelection();
-    const chain = editor.chain().focus();
-    if (selection) {
-      chain.setTextSelection(selection.from);
-    }
-    chain.insertContent({ type: 'genericLink', attrs: { href, text: href } }).run();
+    insertAtSavedEditorSelection(editor, getSavedEditorSelection, { type: 'genericLink', attrs: { href, text: href } });
     setLinkUrl('');
     setActiveToolbarPopover(null);
   };

--- a/src/main/webapp/app/shared/rich-text-editor/addons/ReferenceToolbarAddon.spec.tsx
+++ b/src/main/webapp/app/shared/rich-text-editor/addons/ReferenceToolbarAddon.spec.tsx
@@ -42,7 +42,7 @@ describe('ReferenceToolbarAddon', () => {
     expect(editor.chain).toHaveBeenCalled();
     expect(getSavedEditorSelection).toHaveBeenCalled();
     expect(chain.focus).toHaveBeenCalled();
-    expect(chain.setTextSelection).toHaveBeenCalledWith(4);
+    expect(chain.setTextSelection).toHaveBeenCalledWith({ from: 4, to: 9 });
     expect(chain.insertContent).toHaveBeenCalledWith({ type: 'pmidGroup', attrs: { pmids: ['12345'] } });
     expect(chain.run).toHaveBeenCalled();
     expect(setActiveToolbarPopover).toHaveBeenCalledWith(null);

--- a/src/main/webapp/app/shared/rich-text-editor/addons/ReferenceToolbarAddon.spec.tsx
+++ b/src/main/webapp/app/shared/rich-text-editor/addons/ReferenceToolbarAddon.spec.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { PmidToolbarAddon } from './ReferenceToolbarAddon';
+import { useRichTextEditorContext } from '../RichTextEditor';
+
+jest.mock('../RichTextEditor', () => ({
+  useRichTextEditorContext: jest.fn(),
+}));
+
+describe('ReferenceToolbarAddon', () => {
+  it('restores the saved editor selection before inserting a PMID group', () => {
+    const chain = {
+      focus: jest.fn(),
+      setTextSelection: jest.fn(),
+      insertContent: jest.fn(),
+      run: jest.fn(),
+    };
+    chain.focus.mockReturnValue(chain);
+    chain.setTextSelection.mockReturnValue(chain);
+    chain.insertContent.mockReturnValue(chain);
+    chain.run.mockReturnValue(true);
+
+    const setActiveToolbarPopover = jest.fn();
+    const getSavedEditorSelection = jest.fn(() => ({ from: 4, to: 9 }));
+    const editor = { chain: jest.fn(() => chain) };
+
+    (useRichTextEditorContext as jest.Mock).mockReturnValue({
+      activeToolbarPopover: 'pmid',
+      setActiveToolbarPopover,
+      editor,
+      disabled: false,
+      editorWrapperRef: { current: null },
+      saveEditorSelection: jest.fn(),
+      getSavedEditorSelection,
+    });
+
+    render(<PmidToolbarAddon />);
+
+    fireEvent.change(screen.getByPlaceholderText('PubMed ID'), { target: { value: '12345' } });
+    fireEvent.keyDown(screen.getByPlaceholderText('PubMed ID'), { key: 'Enter', code: 'Enter', charCode: 13 });
+
+    expect(editor.chain).toHaveBeenCalled();
+    expect(getSavedEditorSelection).toHaveBeenCalled();
+    expect(chain.focus).toHaveBeenCalled();
+    expect(chain.setTextSelection).toHaveBeenCalledWith(4);
+    expect(chain.insertContent).toHaveBeenCalledWith({ type: 'pmidGroup', attrs: { pmids: ['12345'] } });
+    expect(chain.run).toHaveBeenCalled();
+    expect(setActiveToolbarPopover).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/main/webapp/app/shared/rich-text-editor/addons/ReferenceToolbarAddon.tsx
+++ b/src/main/webapp/app/shared/rich-text-editor/addons/ReferenceToolbarAddon.tsx
@@ -1,7 +1,9 @@
 import classNames from 'classnames';
+import { Editor } from '@tiptap/core';
 import React, { useState } from 'react';
 import * as styles from '../RichTextEditor.module.scss';
-import { useRichTextEditorContext } from '../RichTextEditor';
+import { RichTextSelectionRange, useRichTextEditorContext } from '../RichTextEditor';
+import { RichTextInlineNode } from '../richTextSchema';
 import { isSafeHttpUrl, normalizeHttpUrl } from '../utils';
 import { buildAbstractReferenceNode, buildNctReferenceNode } from './ReferenceNodeExtensions';
 
@@ -14,6 +16,19 @@ interface ToolbarToggleButtonProps {
   label: string;
   isOpen: boolean;
 }
+
+export const insertAtSavedEditorSelection = (
+  editor: Editor,
+  getSavedEditorSelection: () => RichTextSelectionRange | null,
+  content: RichTextInlineNode,
+) => {
+  const selection = getSavedEditorSelection();
+  const chain = editor.chain().focus();
+  if (selection) {
+    chain.setTextSelection(selection);
+  }
+  return chain.insertContent(content).run();
+};
 
 const ToolbarToggleButton: React.FC<ToolbarToggleButtonProps> = ({ popoverId, label, isOpen }) => {
   const { saveEditorSelection, setActiveToolbarPopover } = useRichTextEditorContext();
@@ -41,12 +56,7 @@ export const PmidToolbarAddon: React.FC = () => {
   const insertPmid = () => {
     const pmid = pmidInput.trim();
     if (!pmid || !editor) return;
-    const selection = getSavedEditorSelection();
-    const chain = editor.chain().focus();
-    if (selection) {
-      chain.setTextSelection(selection.from);
-    }
-    chain.insertContent({ type: 'pmidGroup', attrs: { pmids: [pmid] } }).run();
+    insertAtSavedEditorSelection(editor, getSavedEditorSelection, { type: 'pmidGroup', attrs: { pmids: [pmid] } });
     setPmidInput('');
     setActiveToolbarPopover(null);
   };
@@ -84,12 +94,7 @@ export const NctToolbarAddon: React.FC = () => {
   const insertNct = () => {
     const nctId = nctInput.trim();
     if (!nctId || !editor) return;
-    const selection = getSavedEditorSelection();
-    const chain = editor.chain().focus();
-    if (selection) {
-      chain.setTextSelection(selection.from);
-    }
-    chain.insertContent(buildNctReferenceNode(nctId)).run();
+    insertAtSavedEditorSelection(editor, getSavedEditorSelection, buildNctReferenceNode(nctId));
     setNctInput('');
     setActiveToolbarPopover(null);
   };
@@ -129,12 +134,7 @@ export const AbstractToolbarAddon: React.FC = () => {
     const title = abstractTitle.trim();
     const href = normalizeHttpUrl(abstractLink);
     if (!title || !href || !editor || !isSafeHttpUrl(href)) return;
-    const selection = getSavedEditorSelection();
-    const chain = editor.chain().focus();
-    if (selection) {
-      chain.setTextSelection(selection.from);
-    }
-    chain.insertContent(buildAbstractReferenceNode(title, href)).run();
+    insertAtSavedEditorSelection(editor, getSavedEditorSelection, buildAbstractReferenceNode(title, href));
     setAbstractTitle('');
     setAbstractLink('');
     setActiveToolbarPopover(null);

--- a/src/main/webapp/app/shared/rich-text-editor/addons/ReferenceToolbarAddon.tsx
+++ b/src/main/webapp/app/shared/rich-text-editor/addons/ReferenceToolbarAddon.tsx
@@ -16,13 +16,14 @@ interface ToolbarToggleButtonProps {
 }
 
 const ToolbarToggleButton: React.FC<ToolbarToggleButtonProps> = ({ popoverId, label, isOpen }) => {
-  const { setActiveToolbarPopover } = useRichTextEditorContext();
+  const { saveEditorSelection, setActiveToolbarPopover } = useRichTextEditorContext();
   return (
     <button
       type="button"
       className={classNames(styles.toolbarBtn, isOpen && styles.active)}
       onMouseDown={event => {
         event.preventDefault();
+        saveEditorSelection();
         setActiveToolbarPopover(panel => (panel === popoverId ? null : popoverId));
       }}
       title={label}
@@ -33,18 +34,19 @@ const ToolbarToggleButton: React.FC<ToolbarToggleButtonProps> = ({ popoverId, la
 };
 
 export const PmidToolbarAddon: React.FC = () => {
-  const { activeToolbarPopover, setActiveToolbarPopover, editor } = useRichTextEditorContext();
+  const { activeToolbarPopover, setActiveToolbarPopover, editor, getSavedEditorSelection } = useRichTextEditorContext();
   const [pmidInput, setPmidInput] = useState('');
   const isOpen = activeToolbarPopover === PMID_POPOVER_ID;
 
   const insertPmid = () => {
     const pmid = pmidInput.trim();
     if (!pmid || !editor) return;
-    editor
-      .chain()
-      .focus()
-      .insertContent({ type: 'pmidGroup', attrs: { pmids: [pmid] } })
-      .run();
+    const selection = getSavedEditorSelection();
+    const chain = editor.chain().focus();
+    if (selection) {
+      chain.setTextSelection(selection.from);
+    }
+    chain.insertContent({ type: 'pmidGroup', attrs: { pmids: [pmid] } }).run();
     setPmidInput('');
     setActiveToolbarPopover(null);
   };
@@ -75,14 +77,19 @@ export const PmidToolbarAddon: React.FC = () => {
 };
 
 export const NctToolbarAddon: React.FC = () => {
-  const { activeToolbarPopover, setActiveToolbarPopover, editor } = useRichTextEditorContext();
+  const { activeToolbarPopover, setActiveToolbarPopover, editor, getSavedEditorSelection } = useRichTextEditorContext();
   const [nctInput, setNctInput] = useState('');
   const isOpen = activeToolbarPopover === NCT_POPOVER_ID;
 
   const insertNct = () => {
     const nctId = nctInput.trim();
     if (!nctId || !editor) return;
-    editor.chain().focus().insertContent(buildNctReferenceNode(nctId)).run();
+    const selection = getSavedEditorSelection();
+    const chain = editor.chain().focus();
+    if (selection) {
+      chain.setTextSelection(selection.from);
+    }
+    chain.insertContent(buildNctReferenceNode(nctId)).run();
     setNctInput('');
     setActiveToolbarPopover(null);
   };
@@ -113,7 +120,7 @@ export const NctToolbarAddon: React.FC = () => {
 };
 
 export const AbstractToolbarAddon: React.FC = () => {
-  const { activeToolbarPopover, setActiveToolbarPopover, editor } = useRichTextEditorContext();
+  const { activeToolbarPopover, setActiveToolbarPopover, editor, getSavedEditorSelection } = useRichTextEditorContext();
   const [abstractTitle, setAbstractTitle] = useState('');
   const [abstractLink, setAbstractLink] = useState('');
   const isOpen = activeToolbarPopover === ABSTRACT_POPOVER_ID;
@@ -122,7 +129,12 @@ export const AbstractToolbarAddon: React.FC = () => {
     const title = abstractTitle.trim();
     const href = normalizeHttpUrl(abstractLink);
     if (!title || !href || !editor || !isSafeHttpUrl(href)) return;
-    editor.chain().focus().insertContent(buildAbstractReferenceNode(title, href)).run();
+    const selection = getSavedEditorSelection();
+    const chain = editor.chain().focus();
+    if (selection) {
+      chain.setTextSelection(selection.from);
+    }
+    chain.insertContent(buildAbstractReferenceNode(title, href)).run();
     setAbstractTitle('');
     setAbstractLink('');
     setActiveToolbarPopover(null);


### PR DESCRIPTION
fixes https://github.com/oncokb/oncokb-pipeline/issues/1050

Issue was that when a user places their cursor in the middle of the text and goes to add a reference, the reference ends up getting added to the end of the text
Reason was that the editor's cursor pos was not stored and clicking on the ref button in the toolbar unfocuses the editor and the pos is lost.