### PR TITLE
Fix needsReview for empty sections

### DIFF
--- a/src/main/webapp/app/service/firebase/firebase-gene-review-service.spec.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-review-service.spec.ts
@@ -9,6 +9,7 @@ import { mock, mockReset } from 'jest-mock-extended';
 import { SentryError } from 'app/config/sentry-error';
 import { getTumorNameUuid, ReviewLevel, TumorReviewLevel } from 'app/shared/util/firebase/firebase-review-utils';
 import { ReviewAction } from 'app/config/constants/firebase';
+import { NEW_NAME_UUID_VALUE } from 'app/config/constants/constants';
 import _ from 'lodash';
 import { ActionType } from 'app/pages/curation/collapsible/ReviewCollapsible';
 import { textToTipTapDocWithReferences } from 'app/shared/rich-text-editor/utils';
@@ -128,6 +129,28 @@ describe('Firebase Gene Review Service', () => {
           'Meta/BRAF/lastModifiedBy': mockAuthStore.fullName,
           'Meta/BRAF/lastModifiedAt': DEFAULT_DATETIME_STRING,
           [`Meta/BRAF/review/${DEFAULT_UUID}`]: true,
+        }),
+      );
+    });
+    it('should keep the NEW_NAME_UUID_VALUE sentinel when renaming a not-yet-reviewed added section', async () => {
+      await firebaseGeneReviewService.updateReviewableContent(
+        'Genes/BRAF/mutations/0/name',
+        'old name',
+        'new name',
+        new Review(mockAuthStore.fullName, undefined, true),
+        DEFAULT_UUID,
+      );
+      expect(mockFirebaseRepository.update).toHaveBeenCalledWith(
+        '/',
+        expect.objectContaining({
+          'Genes/BRAF/mutations/0/name': 'new name',
+          'Genes/BRAF/mutations/0/name_review': {
+            added: true,
+            lastReviewed: 'old name',
+            updateTime: DEFAULT_DATE.getTime(),
+            updatedBy: mockAuthStore.fullName,
+          },
+          [`Meta/BRAF/review/${DEFAULT_UUID}`]: NEW_NAME_UUID_VALUE,
         }),
       );
     });

--- a/src/main/webapp/app/service/firebase/firebase-gene-review-service.ts
+++ b/src/main/webapp/app/service/firebase/firebase-gene-review-service.ts
@@ -1,3 +1,4 @@
+import { NEW_NAME_UUID_VALUE } from 'app/config/constants/constants';
 import { ReviewAction } from 'app/config/constants/firebase';
 import { FirebaseHistoryService } from 'app/service/firebase/firebase-history-service';
 import { FirebaseMetaService } from 'app/service/firebase/firebase-meta-service';
@@ -97,7 +98,9 @@ export class FirebaseGeneReviewService {
 
     let updateObject = this.getGeneUpdateObject(updateValue, updatedReview!, firebasePath, uuid!);
     const metaUpdateObject = this.firebaseMetaService.getUpdateObject(hugoSymbol!, isGermline, {
-      [uuid!]: !isChangeReverted ? true : null,
+      // A section that is still a pending create (name_review.added) will keep the NEW_NAME_UUID_VALUE
+      // even when its name is edited. Otherwise fall back to the normal true/null behavior for non name fields.
+      [uuid!]: updatedReview?.added ? NEW_NAME_UUID_VALUE : !isChangeReverted ? true : null,
     });
     updateObject = { ...updateObject, ...metaUpdateObject };
 

--- a/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
+++ b/src/main/webapp/app/shared/util/firebase/firebase-utils.tsx
@@ -90,7 +90,11 @@ export const geneNeedsReview = (meta: Meta | null | undefined) => {
 
 export const mutationNeedsReview = (mutation: Mutation, review: MetaReview) => {
   const ignoreNameChange = mutation.name_review?.added || false;
-  const uuids = Object.keys(review).filter(key => key !== CURRENT_REVIEWER);
+  // A name uuid that was only added (meta value === NEW_NAME_UUID_VALUE) does not require review
+  // on its own, only once other content is curated under the section.
+  const uuids = Object.entries(review)
+    .filter(([key, val]) => key !== CURRENT_REVIEWER && val !== NEW_NAME_UUID_VALUE)
+    .map(([key]) => key);
 
   let nestedObjects = [mutation];
   while (nestedObjects.length > 0) {


### PR DESCRIPTION
fixes https://github.com/oncokb/oncokb-pipeline/issues/1229

- If a mutation/cancer/treatment was created with no data curated, it should not trigger a review. To resolve this, we can use the meta's `[uuid]: "name"` key value pair.
- Also fixed a bug where if you created a new entity, changed the name, then changed it back to original, it would remove the  uuid from meta. This cases would not appear in review anymore.

Fix the firebase right before merging:

## Affected entries

| # | Gene | Mutation | Cancer type | Treatment | uuid |
|---|------|----------|-------------|-----------|------|
| 1 | BRCA1 | Inconclusive Insertion/Deletion mutations at positions 1-1863 [Reversion Mutations] | — | — | `01ef3359-4ce8-491e-90df-6e5f5d4a4d4c` |
| 2 | ERBB2 | Amplification | Breast Cancer | `[IR]` Palbociclib + Trastuzumab + ⟨missing drug⟩ + Pertuzumab (option 2: without Pertuzumab) | `15bd51bf-dae3-42d7-a7e6-2663775f8215` |
| 3 | MECOM | inv(3)(q21.3q26.2), t(3;3)(q21.3;q26.2) | Leukemia / AML with inv(3)(q21.3q26.2) or t(3;3)(q21.3;q26.2); GATA2, MECOM | — | `2335bcbe-5ea5-4b54-a663-156681e75479` |
| 4 | MECOM | inv(3)(q21.3q26.2), t(3;3)(q21.3;q26.2) | — | — | `5d1c68fd-532f-4553-9a72-92e91d614f30` |
| 5 | MECOM | inv(3)(q21.3q26.2), t(3;3)(q21.3;q26.2) | Leukemia / Acute Myeloid Leukemia | — | `f72eabb8-7645-4f1d-98cf-aebb43585351` |

